### PR TITLE
CountryOccupations

### DIFF
--- a/core/src/main/occupations/ArmiesExceptions.kt
+++ b/core/src/main/occupations/ArmiesExceptions.kt
@@ -1,5 +1,6 @@
 package occupations
 
+import Country
 import Player
 
 class NotOccupyingPlayerException(val player: Player) :
@@ -23,3 +24,6 @@ class NonPositiveArmiesRemovedException(val armies: Int) :
 class TooManyArmiesRemovedException(val currentArmies: Int, val removed: Int) :
     Exception("Can't remove $removed armies when there are only $currentArmies armies," +
         " it would leave the country with less than one army.")
+
+class CantRemoveOnlyOccupierException(val country: Country, val player: Player) :
+    Exception("Can't remove $player from $country; they are the only player remaining.")

--- a/core/src/main/occupations/CountryOccupations.kt
+++ b/core/src/main/occupations/CountryOccupations.kt
@@ -61,7 +61,16 @@ class CountryOccupations(private val continents: Set<Continent>) {
         }
 
         override fun visit(occupation: SharedOccupation) {
-            occupations[country] = occupation.removePlayer(player)
+            assertPlayerOccupies(occupation)
+            val otherPlayer = occupation.occupiers.first { it != player }
+            occupations[country] =
+                SinglePlayerOccupation(otherPlayer, occupation.armiesOf(otherPlayer))
+        }
+
+        private fun assertPlayerOccupies(occupation: SharedOccupation) {
+            if (player !in occupation.occupiers) {
+                throw NotOccupyingPlayerException(player)
+            }
         }
     }
 }

--- a/core/src/main/occupations/CountryOccupations.kt
+++ b/core/src/main/occupations/CountryOccupations.kt
@@ -1,0 +1,64 @@
+package occupations
+
+import Continent
+import Country
+import Player
+import assertCountryExists
+
+class CountryOccupations(private val continents: Set<Continent>) {
+
+    private val occupations =
+        mutableMapOf<Country, Occupation>().withDefault { NoOccupation() }
+
+    fun of(country: Country): Occupation {
+        continents.assertCountryExists(country)
+        return occupations.getValue(country)
+    }
+
+    fun occupy(country: Country, player: Player, armies: Int) {
+        assertPlayerDoesNotOccupy(country, player)
+        occupations[country] = SinglePlayerOccupation(player, armies)
+    }
+
+    private fun assertPlayerDoesNotOccupy(country: Country, player: Player) {
+        val occupation = of(country)
+        if (PlayerOccupationChecker(player).doesPlayerOccupy(occupation)) {
+            throw PlayerAlreadyOccupiesCountryException(player)
+        }
+    }
+
+    fun occupy(
+        country: Country,
+        firstPlayer: Player, firstArmies: Int,
+        secondPlayer: Player, secondArmies: Int
+    ) {
+        assertPlayerDoesNotOccupy(country, firstPlayer)
+        assertPlayerDoesNotOccupy(country, secondPlayer)
+        occupations[country] =
+            SharedOccupation(firstPlayer, firstArmies, secondPlayer, secondArmies)
+    }
+}
+
+/**
+ * Checks if the player occupies an Occupation.
+ */
+private class PlayerOccupationChecker(private val player: Player) : OccupationVisitor {
+    private var playerOccupationFlag = false
+
+    fun doesPlayerOccupy(occupation: Occupation): Boolean {
+        occupation.accept(this)
+        return playerOccupationFlag
+    }
+
+    override fun visit(occupation: NoOccupation) {
+        playerOccupationFlag = false
+    }
+
+    override fun visit(occupation: SinglePlayerOccupation) {
+        playerOccupationFlag = player == occupation.occupier
+    }
+
+    override fun visit(occupation: SharedOccupation) {
+        playerOccupationFlag = player in occupation.occupiers
+    }
+}

--- a/core/src/main/occupations/NoOccupation.kt
+++ b/core/src/main/occupations/NoOccupation.kt
@@ -7,4 +7,6 @@ package occupations
  */
 class NoOccupation : Occupation {
     override fun isOccupied() = false
+
+    override fun accept(visitor: OccupationVisitor) = visitor.visit(this)
 }

--- a/core/src/main/occupations/Occupation.kt
+++ b/core/src/main/occupations/Occupation.kt
@@ -9,4 +9,5 @@ package occupations
 interface Occupation {
     fun isOccupied() = true
     fun isShared() = false
+    fun accept(visitor: OccupationVisitor)
 }

--- a/core/src/main/occupations/OccupationVisitor.kt
+++ b/core/src/main/occupations/OccupationVisitor.kt
@@ -1,0 +1,7 @@
+package occupations
+
+interface OccupationVisitor {
+    fun visit(occupation: NoOccupation)
+    fun visit(occupation: SinglePlayerOccupation)
+    fun visit(occupation: SharedOccupation)
+}

--- a/core/src/main/occupations/PlayerOccupationChecker.kt
+++ b/core/src/main/occupations/PlayerOccupationChecker.kt
@@ -1,0 +1,27 @@
+package occupations
+
+import Player
+
+/**
+ * Checks if the player occupies an Occupation.
+ */
+class PlayerOccupationChecker(private val player: Player) : OccupationVisitor {
+    private var playerOccupationFlag = false
+
+    fun doesPlayerOccupy(occupation: Occupation): Boolean {
+        occupation.accept(this)
+        return playerOccupationFlag
+    }
+
+    override fun visit(occupation: NoOccupation) {
+        playerOccupationFlag = false
+    }
+
+    override fun visit(occupation: SinglePlayerOccupation) {
+        playerOccupationFlag = player == occupation.occupier
+    }
+
+    override fun visit(occupation: SharedOccupation) {
+        playerOccupationFlag = player in occupation.occupiers
+    }
+}

--- a/core/src/main/occupations/SharedOccupation.kt
+++ b/core/src/main/occupations/SharedOccupation.kt
@@ -38,12 +38,6 @@ class SharedOccupation(
     fun removeArmies(removed: Int, player: Player) =
         occupations.getValue(player).removeArmies(removed)
 
-    fun removePlayer(player: Player): SinglePlayerOccupation {
-        assertPlayerIsOccupying(player)
-        val otherPlayer = occupiers.first { it != player }
-        return occupations.getValue(otherPlayer)
-    }
-
     private fun assertPlayerIsOccupying(player: Player) {
         if (player !in occupiers) {
             throw NotOccupyingPlayerException(player)

--- a/core/src/main/occupations/SharedOccupation.kt
+++ b/core/src/main/occupations/SharedOccupation.kt
@@ -66,4 +66,6 @@ class SharedOccupation(
     private fun addPlayer(player: Player, armies: Int) {
         occupations[player] = SinglePlayerOccupation(player, armies)
     }
+
+    override fun accept(visitor: OccupationVisitor) = visitor.visit(this)
 }

--- a/core/src/main/occupations/SinglePlayerOccupation.kt
+++ b/core/src/main/occupations/SinglePlayerOccupation.kt
@@ -48,4 +48,6 @@ class SinglePlayerOccupation(
             throw TooManyArmiesRemovedException(armies, removed)
         }
     }
+
+    override fun accept(visitor: OccupationVisitor) = visitor.visit(this)
 }

--- a/core/src/test/occupations/CountryOccupationsTest.kt
+++ b/core/src/test/occupations/CountryOccupationsTest.kt
@@ -87,6 +87,17 @@ class CountryOccupationsTest {
     }
 
     @Test
+    fun `Can't occupy a non-existent country with a single player`() {
+        val occupations = CountryOccupations(someContinentSet)
+
+        val exception = assertFailsWith<NonExistentCountryException> {
+            occupations.occupy(nonExistentCountry, somePlayer, someArmies)
+        }
+
+        assertEquals(nonExistentCountry, exception.country)
+    }
+
+    @Test
     fun `Occupying a country with two players makes it shared`() {
         val occupations = CountryOccupations(someContinentSet)
 
@@ -144,6 +155,17 @@ class CountryOccupationsTest {
         val occupation = occupations.of(someCountry) as SinglePlayerOccupation
         assertEquals(somePlayer, occupation.occupier)
         assertEquals(someArmies, occupation.armies)
+    }
+
+    @Test
+    fun `Can't occupy a non-existent country with two players`() {
+        val occupations = CountryOccupations(someContinentSet)
+
+        val exception = assertFailsWith<NonExistentCountryException> {
+            occupations.occupy(nonExistentCountry, somePlayer, someArmies, anotherPlayer, otherArmies)
+        }
+
+        assertEquals(nonExistentCountry, exception.country)
     }
 
     @Test

--- a/core/src/test/occupations/CountryOccupationsTest.kt
+++ b/core/src/test/occupations/CountryOccupationsTest.kt
@@ -1,0 +1,148 @@
+package occupations
+
+import Continent
+import NonExistentCountryException
+import kotlin.test.*
+
+class CountryOccupationsTest {
+
+    private val someCountry = "Argentina"
+    private val otherCountry = "Brasil"
+    private val nonExistentCountry = "Uruguay"
+    private val someContinent = Continent("America", setOf(someCountry, otherCountry))
+    private val someContinentSet = setOf(someContinent)
+    private val somePlayer = "Popeye"
+    private val otherPlayer = "Graciela"
+    private val anotherPlayer = "Julieta"
+    private val someArmies = 3
+    private val otherArmies = 1
+    private val anotherArmies = 2
+
+    @Test
+    fun `At first all countries are unoccupied`() {
+        val occupations = CountryOccupations(someContinentSet)
+
+        assertFalse(occupations.of(someCountry).isOccupied())
+    }
+
+    @Test
+    fun `Can't ask for the occupation of a non-existent country`() {
+        val occupations = CountryOccupations(someContinentSet)
+
+        val exception = assertFailsWith<NonExistentCountryException> {
+            occupations.of(nonExistentCountry)
+        }
+
+        assertEquals(nonExistentCountry, exception.country)
+    }
+
+    @Test
+    fun `Occupying a country with one player makes it occupied by that player`() {
+        val occupations = CountryOccupations(someContinentSet)
+
+        occupations.occupy(someCountry, somePlayer, someArmies)
+
+        val occupation = occupations.of(someCountry) as SinglePlayerOccupation
+        assertTrue(occupation.isOccupied())
+        assertEquals(somePlayer, occupation.occupier)
+        assertEquals(someArmies, occupation.armies)
+    }
+
+    @Test
+    fun `Occupying a country does not occupy all the others`() {
+        val occupations = CountryOccupations(someContinentSet)
+
+        occupations.occupy(someCountry, somePlayer, someArmies)
+
+        val occupation = occupations.of(otherCountry)
+        assertFalse(occupation.isOccupied())
+    }
+
+    @Test
+    fun `Can't occupy a country already occupied by the same single player`() {
+        val occupations = CountryOccupations(someContinentSet)
+
+        occupations.occupy(someCountry, somePlayer, someArmies)
+
+        val exception = assertFailsWith<PlayerAlreadyOccupiesCountryException> {
+            occupations.occupy(someCountry, somePlayer, someArmies)
+        }
+        assertEquals(somePlayer, exception.player)
+        val occupation = occupations.of(someCountry) as SinglePlayerOccupation
+        assertTrue(occupation.isOccupied())
+        assertEquals(somePlayer, occupation.occupier)
+        assertEquals(someArmies, occupation.armies)
+    }
+
+    @Test
+    fun `Can occupy a country occupied by other single player`() {
+        val occupations = CountryOccupations(someContinentSet)
+
+        occupations.occupy(someCountry, somePlayer, someArmies)
+        occupations.occupy(someCountry, otherPlayer, otherArmies)
+
+        val occupation = occupations.of(someCountry) as SinglePlayerOccupation
+        assertEquals(otherPlayer, occupation.occupier)
+        assertEquals(otherArmies, occupation.armies)
+    }
+
+    @Test
+    fun `Occupying a country with two players makes it shared`() {
+        val occupations = CountryOccupations(someContinentSet)
+
+        occupations.occupy(someCountry, somePlayer, someArmies, otherPlayer, otherArmies)
+
+        val occupation = occupations.of(someCountry) as SharedOccupation
+        assertEquals(setOf(somePlayer, otherPlayer), occupation.occupiers)
+        assertEquals(someArmies, occupation.armiesOf(somePlayer))
+        assertEquals(otherArmies, occupation.armiesOf(otherPlayer))
+    }
+
+    @Test
+    fun `Can't occupy a country with one player when he is one of the players occupying`() {
+        val occupations = CountryOccupations(someContinentSet)
+
+        occupations.occupy(someCountry, somePlayer, someArmies, otherPlayer, otherArmies)
+
+        val exception = assertFailsWith<PlayerAlreadyOccupiesCountryException> {
+            occupations.occupy(someCountry, somePlayer, anotherArmies)
+        }
+
+        assertEquals(somePlayer, exception.player)
+        val occupation = occupations.of(someCountry) as SharedOccupation
+        assertEquals(setOf(somePlayer, otherPlayer), occupation.occupiers)
+        assertEquals(someArmies, occupation.armiesOf(somePlayer))
+        assertEquals(otherArmies, occupation.armiesOf(otherPlayer))
+    }
+
+    @Test
+    fun `Can't occupy a country with two players when the first one is already occupying the country`() {
+        val occupations = CountryOccupations(someContinentSet)
+
+        occupations.occupy(someCountry, somePlayer, someArmies, otherPlayer, otherArmies)
+        val exception = assertFailsWith<PlayerAlreadyOccupiesCountryException> {
+            occupations.occupy(someCountry, somePlayer, anotherArmies, anotherPlayer, someArmies)
+        }
+
+        assertEquals(somePlayer, exception.player)
+        val occupation = occupations.of(someCountry) as SharedOccupation
+        assertEquals(setOf(somePlayer, otherPlayer), occupation.occupiers)
+        assertEquals(someArmies, occupation.armiesOf(somePlayer))
+        assertEquals(otherArmies, occupation.armiesOf(otherPlayer))
+    }
+
+    @Test
+    fun `Can't occupy a country with two players when the second one is already occupying the country`() {
+        val occupations = CountryOccupations(someContinentSet)
+
+        occupations.occupy(someCountry, somePlayer, someArmies)
+        val exception = assertFailsWith<PlayerAlreadyOccupiesCountryException> {
+            occupations.occupy(someCountry, otherPlayer, anotherArmies, somePlayer, someArmies)
+        }
+
+        assertEquals(somePlayer, exception.player)
+        val occupation = occupations.of(someCountry) as SinglePlayerOccupation
+        assertEquals(somePlayer, occupation.occupier)
+        assertEquals(someArmies, occupation.armies)
+    }
+}

--- a/core/src/test/occupations/CountryOccupationsTest.kt
+++ b/core/src/test/occupations/CountryOccupationsTest.kt
@@ -145,4 +145,46 @@ class CountryOccupationsTest {
         assertEquals(somePlayer, occupation.occupier)
         assertEquals(someArmies, occupation.armies)
     }
+
+    @Test
+    fun `Removing a player from a shared occupation makes the other player the only occupier`() {
+        val occupations = CountryOccupations(someContinentSet)
+
+        occupations.occupy(someCountry, somePlayer, someArmies, otherPlayer, otherArmies)
+        occupations.remove(someCountry, somePlayer)
+
+        val occupation = occupations.of(someCountry) as SinglePlayerOccupation
+        assertEquals(otherPlayer, occupation.occupier)
+        assertEquals(otherArmies, occupation.armies)
+    }
+
+    @Test
+    fun `Can't remove a player from a country occupied by only one player`() {
+        val occupations = CountryOccupations(someContinentSet)
+
+        occupations.occupy(someCountry, somePlayer, someArmies)
+
+        val exception = assertFailsWith<CantRemoveOnlyOccupierException> {
+            occupations.remove(someCountry, somePlayer)
+        }
+
+        assertEquals(somePlayer, exception.player)
+        assertEquals(someCountry, exception.country)
+
+        val occupation = occupations.of(someCountry) as SinglePlayerOccupation
+        assertEquals(somePlayer, occupation.occupier)
+        assertEquals(someArmies, occupation.armies)
+    }
+
+    @Test
+    fun `Can't remove a player from a country not occupied by anyone`() {
+        val occupations = CountryOccupations(someContinentSet)
+
+        val exception = assertFailsWith<NotOccupyingPlayerException> {
+            occupations.remove(someCountry, somePlayer)
+        }
+
+        assertEquals(somePlayer, exception.player)
+        assertFalse(occupations.of(someCountry).isOccupied())
+    }
 }

--- a/core/src/test/occupations/CountryOccupationsTest.kt
+++ b/core/src/test/occupations/CountryOccupationsTest.kt
@@ -187,4 +187,20 @@ class CountryOccupationsTest {
         assertEquals(somePlayer, exception.player)
         assertFalse(occupations.of(someCountry).isOccupied())
     }
+
+    @Test
+    fun `Can't remove a player that is not sharing country`() {
+        val occupations = CountryOccupations(someContinentSet)
+
+        occupations.occupy(someCountry, somePlayer, someArmies, otherPlayer, otherArmies)
+        val exception = assertFailsWith<NotOccupyingPlayerException> {
+            occupations.remove(someCountry, anotherPlayer)
+        }
+
+        assertEquals(anotherPlayer, exception.player)
+        val occupation = occupations.of(someCountry) as SharedOccupation
+        assertEquals(setOf(somePlayer, otherPlayer), occupation.occupiers)
+        assertEquals(someArmies, occupation.armiesOf(somePlayer))
+        assertEquals(otherArmies, occupation.armiesOf(otherPlayer))
+    }
 }

--- a/core/src/test/occupations/NoOccupationTest.kt
+++ b/core/src/test/occupations/NoOccupationTest.kt
@@ -1,9 +1,6 @@
 package occupations
 
-import kotlin.test.BeforeTest
-import kotlin.test.Test
-import kotlin.test.assertEquals
-import kotlin.test.assertFalse
+import kotlin.test.*
 
 class NoOccupationTest {
 
@@ -26,5 +23,27 @@ class NoOccupationTest {
     @Test
     fun `NoOccupation is not shared`() {
         assertFalse(occupation.isShared())
+    }
+
+    @Test
+    fun `visitNoOccupation gets called when visiting a NoOccupation`() {
+        var timesCalled = 0
+        val visitor = object : OccupationVisitor {
+            override fun visit(occupation: NoOccupation) {
+                timesCalled++
+            }
+
+            override fun visit(occupation: SinglePlayerOccupation) {
+                fail("Should not visit a SinglePlayerOccupation")
+            }
+
+            override fun visit(occupation: SharedOccupation) {
+                fail("Should not visit a SharedOccupation")
+            }
+        }
+
+        occupation.accept(visitor)
+
+        assertEquals(1, timesCalled, "visit(NoOccupation) should be called one time.")
     }
 }

--- a/core/src/test/occupations/SharedOccupationTest.kt
+++ b/core/src/test/occupations/SharedOccupationTest.kt
@@ -1,9 +1,6 @@
 package occupations
 
-import kotlin.test.Test
-import kotlin.test.assertEquals
-import kotlin.test.assertFailsWith
-import kotlin.test.assertTrue
+import kotlin.test.*
 
 class SharedOccupationTest {
 
@@ -228,5 +225,28 @@ class SharedOccupationTest {
         assertEquals(otherPlayer, exception.player)
         assertEquals(setOf(somePlayer, otherPlayer), occupation.occupiers)
         assertEquals(armies, occupation.armiesOf(somePlayer))
+    }
+
+    @Test
+    fun `Correct visit gets called when visiting a SharedOccupation`() {
+        var timesCalled = 0
+        val visitor = object : OccupationVisitor {
+            override fun visit(occupation: NoOccupation) {
+                fail("Should not visit a NoOccupation.")
+            }
+
+            override fun visit(occupation: SinglePlayerOccupation) {
+                fail("Should not visit a SinglePlayerOccupation.")
+            }
+
+            override fun visit(occupation: SharedOccupation) {
+                timesCalled++
+            }
+        }
+
+        val occupation = SharedOccupation(somePlayer, 1, otherPlayer, 2)
+        occupation.accept(visitor)
+
+        assertEquals(1, timesCalled, "visit(SharedOccupation) should be called one time")
     }
 }

--- a/core/src/test/occupations/SharedOccupationTest.kt
+++ b/core/src/test/occupations/SharedOccupationTest.kt
@@ -166,30 +166,6 @@ class SharedOccupationTest {
     }
 
     @Test
-    fun `Removing a player from a SharedOccupation returns an occupation with just the remaining player`() {
-        val armies = 2
-        val occupation =
-            SharedOccupation(somePlayer, 1, otherPlayer, armies)
-
-        val newOccupation = occupation.removePlayer(somePlayer)
-
-        assertEquals(otherPlayer, newOccupation.occupier)
-        assertEquals(armies, newOccupation.armies)
-    }
-
-    @Test
-    fun `Can't remove a player not part of the occupiers`() {
-        val armies = 2
-        val occupation =
-            SharedOccupation(somePlayer, 1, otherPlayer, armies)
-
-        val exception = assertFailsWith<NotOccupyingPlayerException> {
-            occupation.removePlayer(anotherPlayer)
-        }
-        assertEquals(anotherPlayer, exception.player)
-    }
-
-    @Test
     fun `Occupying a player's share changes the removed player for the occupier`() {
         val firstArmies = 2
         val occupation =

--- a/core/src/test/occupations/SinglePlayerOccupationTest.kt
+++ b/core/src/test/occupations/SinglePlayerOccupationTest.kt
@@ -151,4 +151,28 @@ class SinglePlayerOccupationTest {
         assertEquals(originalArmies, exception.removed)
         assertEquals(originalArmies, occupation.armies)
     }
+
+    @Test
+    fun `Correct visit gets called when visiting a SinglePlayerOccupation`() {
+        var timesCalled = 0
+        val visitor = object : OccupationVisitor {
+            override fun visit(occupation: NoOccupation) {
+                fail("Should not visit a NoOccupation")
+            }
+
+            override fun visit(occupation: SinglePlayerOccupation) {
+                timesCalled++
+            }
+
+            override fun visit(occupation: SharedOccupation) {
+                fail("Should not visit a SharedOccupation")
+            }
+        }
+
+        val occupation = SinglePlayerOccupation(somePlayer, 1)
+        occupation.accept(visitor)
+
+        assertEquals(
+            1, timesCalled, "visit(SinglePlayerOccupation) should be called one time.")
+    }
 }


### PR DESCRIPTION
Adds class `CountryOccupations` that lets you manage a set of `Occupation`s for a group of countries, allowing you to occupy countries and remove players from occupations.

Also adds the Visitor pattern to `Occupation`, because we will probably be doing very different things with a `SharedOccupation` than with a `SinglePlayerOccupation` and a `NoOccupation`.