### PR TITLE
CombatResolver

### DIFF
--- a/core/src/main/combat/CombatExceptions.kt
+++ b/core/src/main/combat/CombatExceptions.kt
@@ -1,0 +1,7 @@
+package combat
+
+class TooManyArmiesContestedException(val armies: Int) : IllegalArgumentException(
+    "Can't contest $armies armies, there's not enough dice rolls to decide who wins.")
+
+class NonPositiveArmiesContestedException(val armies: Int) : IllegalArgumentException(
+    "Can't contest non-positive amount of armies $armies.")

--- a/core/src/main/combat/CombatExceptions.kt
+++ b/core/src/main/combat/CombatExceptions.kt
@@ -1,7 +1,6 @@
 package combat
 
-class TooManyArmiesContestedException(val armies: Int) : IllegalArgumentException(
-    "Can't contest $armies armies, there's not enough dice rolls to decide who wins.")
+import PositiveInt
 
-class NonPositiveArmiesContestedException(val armies: Int) : IllegalArgumentException(
-    "Can't contest non-positive amount of armies $armies.")
+class TooManyArmiesContestedException(val armies: PositiveInt) : IllegalArgumentException(
+    "Can't contest $armies armies, there's not enough dice rolls to decide who wins.")

--- a/core/src/main/combat/CombatResolver.kt
+++ b/core/src/main/combat/CombatResolver.kt
@@ -1,0 +1,51 @@
+package combat
+
+import kotlin.math.min
+
+/**
+ * Resolves combats between an attacker and a defender,
+ * using the rolls passed as a parameter to determine how many armies each one lost.
+ *
+ * The lost armies total is equal to the amount contested.
+ */
+class CombatResolver {
+    fun combat(
+        attackerRolls: Collection<Int>, defenderRolls: Collection<Int>,
+        contestedArmies: Int
+    ): Pair<Int, Int> {
+
+        assertPositiveAmountOfArmiesContested(contestedArmies)
+        assertEnoughDiceForContestedArmies(
+            attackerRolls.size, defenderRolls.size, contestedArmies)
+
+        val armiesLostByDefender = min(
+            rollsLostByDefender(attackerRolls, defenderRolls),
+            contestedArmies
+        )
+        val armiesLostByAttacker = contestedArmies - armiesLostByDefender
+        return Pair(armiesLostByAttacker, armiesLostByDefender)
+    }
+
+    private fun assertPositiveAmountOfArmiesContested(contestedArmies: Int) {
+        if (contestedArmies <= 0) {
+            throw NonPositiveArmiesContestedException(contestedArmies)
+        }
+    }
+
+    private fun assertEnoughDiceForContestedArmies(
+        attackerDice: Int, defenderDice: Int, contestedArmies: Int) {
+        if (min(attackerDice, defenderDice) < contestedArmies) {
+            throw TooManyArmiesContestedException(contestedArmies)
+        }
+    }
+
+    private fun rollsLostByDefender(
+        attackerRolls: Collection<Int>, defenderRolls: Collection<Int>): Int {
+        val sortedAttackerRolls = attackerRolls.sortedDescending()
+        val sortedDefenderRolls = defenderRolls.sortedDescending()
+        val pairedRolls = sortedAttackerRolls.zip(sortedDefenderRolls)
+        return pairedRolls.count { (attackerResult, defenderResult) ->
+            attackerResult > defenderResult
+        }
+    }
+}

--- a/core/src/main/combat/CombatResolver.kt
+++ b/core/src/main/combat/CombatResolver.kt
@@ -1,5 +1,6 @@
 package combat
 
+import PositiveInt
 import kotlin.math.min
 
 /**
@@ -11,30 +12,23 @@ import kotlin.math.min
 class CombatResolver {
     fun combat(
         attackerRolls: Collection<Int>, defenderRolls: Collection<Int>,
-        contestedArmies: Int
+        contestedArmies: PositiveInt
     ): Pair<Int, Int> {
 
-        assertPositiveAmountOfArmiesContested(contestedArmies)
         assertEnoughDiceForContestedArmies(
             attackerRolls.size, defenderRolls.size, contestedArmies)
 
         val armiesLostByDefender = min(
             rollsLostByDefender(attackerRolls, defenderRolls),
-            contestedArmies
+            contestedArmies.toInt()
         )
-        val armiesLostByAttacker = contestedArmies - armiesLostByDefender
+        val armiesLostByAttacker = contestedArmies.toInt() - armiesLostByDefender
         return Pair(armiesLostByAttacker, armiesLostByDefender)
     }
 
-    private fun assertPositiveAmountOfArmiesContested(contestedArmies: Int) {
-        if (contestedArmies <= 0) {
-            throw NonPositiveArmiesContestedException(contestedArmies)
-        }
-    }
-
     private fun assertEnoughDiceForContestedArmies(
-        attackerDice: Int, defenderDice: Int, contestedArmies: Int) {
-        if (min(attackerDice, defenderDice) < contestedArmies) {
+        attackerDice: Int, defenderDice: Int, contestedArmies: PositiveInt) {
+        if (min(attackerDice, defenderDice) < contestedArmies.toInt()) {
             throw TooManyArmiesContestedException(contestedArmies)
         }
     }

--- a/core/src/test/combat/CombatResolverTest.kt
+++ b/core/src/test/combat/CombatResolverTest.kt
@@ -1,5 +1,6 @@
 package combat
 
+import PositiveInt
 import kotlin.test.BeforeTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
@@ -18,9 +19,10 @@ class CombatResolverTest {
     fun `Attacker wins when he rolls higher`() {
         val attackerRolls = listOf(6)
         val defenderRolls = listOf(1)
+        val contestedArmies = PositiveInt(1)
 
         val (lostAttackerArmies, lostDefenderArmies) =
-            resolver.combat(attackerRolls, defenderRolls, contestedArmies = 1)
+            resolver.combat(attackerRolls, defenderRolls, contestedArmies)
 
         assertEquals(0, lostAttackerArmies)
         assertEquals(1, lostDefenderArmies)
@@ -30,9 +32,10 @@ class CombatResolverTest {
     fun `Defender wins when he rolls higher`() {
         val attackerRolls = listOf(1)
         val defenderRolls = listOf(6)
+        val contestedArmies = PositiveInt(1)
 
         val (lostAttackerArmies, lostDefenderArmies) =
-            resolver.combat(attackerRolls, defenderRolls, contestedArmies = 1)
+            resolver.combat(attackerRolls, defenderRolls, contestedArmies)
 
         assertEquals(1, lostAttackerArmies)
         assertEquals(0, lostDefenderArmies)
@@ -42,9 +45,10 @@ class CombatResolverTest {
     fun `Defender wins when there's a tie`() {
         val attackerRolls = listOf(3)
         val defenderRolls = listOf(3)
+        val contestedArmies = PositiveInt(1)
 
         val (lostAttackerArmies, lostDefenderArmies) =
-            resolver.combat(attackerRolls, defenderRolls, contestedArmies = 1)
+            resolver.combat(attackerRolls, defenderRolls, contestedArmies)
 
         assertEquals(1, lostAttackerArmies)
         assertEquals(0, lostDefenderArmies)
@@ -54,9 +58,10 @@ class CombatResolverTest {
     fun `Attacker can win more than one roll`() {
         val attackerRolls = listOf(6, 5)
         val defenderRolls = listOf(2, 1)
+        val contestedArmies = PositiveInt(2)
 
         val (lostAttackerArmies, lostDefenderArmies) =
-            resolver.combat(attackerRolls, defenderRolls, contestedArmies = 2)
+            resolver.combat(attackerRolls, defenderRolls, contestedArmies)
 
         assertEquals(0, lostAttackerArmies)
         assertEquals(2, lostDefenderArmies)
@@ -66,9 +71,10 @@ class CombatResolverTest {
     fun `Attacker rolls are sorted before evaluating the results`() {
         val attackerRolls = listOf(1, 6)
         val defenderRolls = listOf(2)
+        val contestedArmies = PositiveInt(1)
 
         val (lostAttackerArmies, lostDefenderArmies) =
-            resolver.combat(attackerRolls, defenderRolls, contestedArmies = 1)
+            resolver.combat(attackerRolls, defenderRolls, contestedArmies)
 
         assertEquals(0, lostAttackerArmies)
         assertEquals(1, lostDefenderArmies)
@@ -78,9 +84,10 @@ class CombatResolverTest {
     fun `Defender rolls are sorted before evaluating the results`() {
         val attackerRolls = listOf(6)
         val defenderRolls = listOf(2, 6)
+        val contestedArmies = PositiveInt(1)
 
         val (lostAttackerArmies, lostDefenderArmies) =
-            resolver.combat(attackerRolls, defenderRolls, contestedArmies = 1)
+            resolver.combat(attackerRolls, defenderRolls, contestedArmies)
 
         assertEquals(1, lostAttackerArmies)
         assertEquals(0, lostDefenderArmies)
@@ -90,9 +97,10 @@ class CombatResolverTest {
     fun `Attacker can't win more than the contested armies`() {
         val attackerRolls = listOf(6, 3)
         val defenderRolls = listOf(1, 5)
+        val contestedArmies = PositiveInt(1)
 
         val (lostAttackerArmies, lostDefenderArmies) =
-            resolver.combat(attackerRolls, defenderRolls, contestedArmies = 1)
+            resolver.combat(attackerRolls, defenderRolls, contestedArmies)
 
         assertEquals(0, lostAttackerArmies)
         assertEquals(1, lostDefenderArmies)
@@ -102,9 +110,10 @@ class CombatResolverTest {
     fun `Defender can't win more than the contested armies`() {
         val attackerRolls = listOf(1, 2)
         val defenderRolls = listOf(1, 5)
+        val contestedArmies = PositiveInt(1)
 
         val (lostAttackerArmies, lostDefenderArmies) =
-            resolver.combat(attackerRolls, defenderRolls, contestedArmies = 1)
+            resolver.combat(attackerRolls, defenderRolls, contestedArmies)
 
         assertEquals(1, lostAttackerArmies)
         assertEquals(0, lostDefenderArmies)
@@ -112,7 +121,7 @@ class CombatResolverTest {
 
     @Test
     fun `Can't contest more armies than the attacker's rolled dice`() {
-        val contested = 2
+        val contested = PositiveInt(2)
         val exception = assertFailsWith<TooManyArmiesContestedException> {
             resolver.combat(listOf(1), listOf(2, 3), contestedArmies = contested)
         }
@@ -121,27 +130,9 @@ class CombatResolverTest {
 
     @Test
     fun `Can't contest more armies than the defender's rolled dice`() {
-        val contested = 3
+        val contested = PositiveInt(3)
         val exception = assertFailsWith<TooManyArmiesContestedException> {
             resolver.combat(listOf(1, 2, 3, 4), listOf(1), contestedArmies = contested)
-        }
-        assertEquals(contested, exception.armies)
-    }
-
-    @Test
-    fun `Can't contest a negative amount of armies`() {
-        val contested = -1
-        val exception = assertFailsWith<NonPositiveArmiesContestedException> {
-            resolver.combat(listOf(1), listOf(1), contestedArmies = contested)
-        }
-        assertEquals(contested, exception.armies)
-    }
-
-    @Test
-    fun `Can't contest zero armies`() {
-        val contested = 0
-        val exception = assertFailsWith<NonPositiveArmiesContestedException> {
-            resolver.combat(listOf(1), listOf(1), contestedArmies = contested)
         }
         assertEquals(contested, exception.armies)
     }

--- a/core/src/test/combat/CombatResolverTest.kt
+++ b/core/src/test/combat/CombatResolverTest.kt
@@ -1,0 +1,148 @@
+package combat
+
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+
+class CombatResolverTest {
+
+    private lateinit var resolver: CombatResolver
+
+    @BeforeTest
+    fun setup() {
+        resolver = CombatResolver()
+    }
+
+    @Test
+    fun `Attacker wins when he rolls higher`() {
+        val attackerRolls = listOf(6)
+        val defenderRolls = listOf(1)
+
+        val (lostAttackerArmies, lostDefenderArmies) =
+            resolver.combat(attackerRolls, defenderRolls, contestedArmies = 1)
+
+        assertEquals(0, lostAttackerArmies)
+        assertEquals(1, lostDefenderArmies)
+    }
+
+    @Test
+    fun `Defender wins when he rolls higher`() {
+        val attackerRolls = listOf(1)
+        val defenderRolls = listOf(6)
+
+        val (lostAttackerArmies, lostDefenderArmies) =
+            resolver.combat(attackerRolls, defenderRolls, contestedArmies = 1)
+
+        assertEquals(1, lostAttackerArmies)
+        assertEquals(0, lostDefenderArmies)
+    }
+
+    @Test
+    fun `Defender wins when there's a tie`() {
+        val attackerRolls = listOf(3)
+        val defenderRolls = listOf(3)
+
+        val (lostAttackerArmies, lostDefenderArmies) =
+            resolver.combat(attackerRolls, defenderRolls, contestedArmies = 1)
+
+        assertEquals(1, lostAttackerArmies)
+        assertEquals(0, lostDefenderArmies)
+    }
+
+    @Test
+    fun `Attacker can win more than one roll`() {
+        val attackerRolls = listOf(6, 5)
+        val defenderRolls = listOf(2, 1)
+
+        val (lostAttackerArmies, lostDefenderArmies) =
+            resolver.combat(attackerRolls, defenderRolls, contestedArmies = 2)
+
+        assertEquals(0, lostAttackerArmies)
+        assertEquals(2, lostDefenderArmies)
+    }
+
+    @Test
+    fun `Attacker rolls are sorted before evaluating the results`() {
+        val attackerRolls = listOf(1, 6)
+        val defenderRolls = listOf(2)
+
+        val (lostAttackerArmies, lostDefenderArmies) =
+            resolver.combat(attackerRolls, defenderRolls, contestedArmies = 1)
+
+        assertEquals(0, lostAttackerArmies)
+        assertEquals(1, lostDefenderArmies)
+    }
+
+    @Test
+    fun `Defender rolls are sorted before evaluating the results`() {
+        val attackerRolls = listOf(6)
+        val defenderRolls = listOf(2, 6)
+
+        val (lostAttackerArmies, lostDefenderArmies) =
+            resolver.combat(attackerRolls, defenderRolls, contestedArmies = 1)
+
+        assertEquals(1, lostAttackerArmies)
+        assertEquals(0, lostDefenderArmies)
+    }
+
+    @Test
+    fun `Attacker can't win more than the contested armies`() {
+        val attackerRolls = listOf(6, 3)
+        val defenderRolls = listOf(1, 5)
+
+        val (lostAttackerArmies, lostDefenderArmies) =
+            resolver.combat(attackerRolls, defenderRolls, contestedArmies = 1)
+
+        assertEquals(0, lostAttackerArmies)
+        assertEquals(1, lostDefenderArmies)
+    }
+
+    @Test
+    fun `Defender can't win more than the contested armies`() {
+        val attackerRolls = listOf(1, 2)
+        val defenderRolls = listOf(1, 5)
+
+        val (lostAttackerArmies, lostDefenderArmies) =
+            resolver.combat(attackerRolls, defenderRolls, contestedArmies = 1)
+
+        assertEquals(1, lostAttackerArmies)
+        assertEquals(0, lostDefenderArmies)
+    }
+
+    @Test
+    fun `Can't contest more armies than the attacker's rolled dice`() {
+        val contested = 2
+        val exception = assertFailsWith<TooManyArmiesContestedException> {
+            resolver.combat(listOf(1), listOf(2, 3), contestedArmies = contested)
+        }
+        assertEquals(contested, exception.armies)
+    }
+
+    @Test
+    fun `Can't contest more armies than the defender's rolled dice`() {
+        val contested = 3
+        val exception = assertFailsWith<TooManyArmiesContestedException> {
+            resolver.combat(listOf(1, 2, 3, 4), listOf(1), contestedArmies = contested)
+        }
+        assertEquals(contested, exception.armies)
+    }
+
+    @Test
+    fun `Can't contest a negative amount of armies`() {
+        val contested = -1
+        val exception = assertFailsWith<NonPositiveArmiesContestedException> {
+            resolver.combat(listOf(1), listOf(1), contestedArmies = contested)
+        }
+        assertEquals(contested, exception.armies)
+    }
+
+    @Test
+    fun `Can't contest zero armies`() {
+        val contested = 0
+        val exception = assertFailsWith<NonPositiveArmiesContestedException> {
+            resolver.combat(listOf(1), listOf(1), contestedArmies = contested)
+        }
+        assertEquals(contested, exception.armies)
+    }
+}

--- a/core/src/test/combat/CombatResolverTest.kt
+++ b/core/src/test/combat/CombatResolverTest.kt
@@ -1,10 +1,10 @@
 package combat
 
-import PositiveInt
 import kotlin.test.BeforeTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
+import PositiveInt as Pos
 
 class CombatResolverTest {
 
@@ -19,7 +19,7 @@ class CombatResolverTest {
     fun `Attacker wins when he rolls higher`() {
         val attackerRolls = listOf(6)
         val defenderRolls = listOf(1)
-        val contestedArmies = PositiveInt(1)
+        val contestedArmies = Pos(1)
 
         val (lostAttackerArmies, lostDefenderArmies) =
             resolver.combat(attackerRolls, defenderRolls, contestedArmies)
@@ -32,7 +32,7 @@ class CombatResolverTest {
     fun `Defender wins when he rolls higher`() {
         val attackerRolls = listOf(1)
         val defenderRolls = listOf(6)
-        val contestedArmies = PositiveInt(1)
+        val contestedArmies = Pos(1)
 
         val (lostAttackerArmies, lostDefenderArmies) =
             resolver.combat(attackerRolls, defenderRolls, contestedArmies)
@@ -45,7 +45,7 @@ class CombatResolverTest {
     fun `Defender wins when there's a tie`() {
         val attackerRolls = listOf(3)
         val defenderRolls = listOf(3)
-        val contestedArmies = PositiveInt(1)
+        val contestedArmies = Pos(1)
 
         val (lostAttackerArmies, lostDefenderArmies) =
             resolver.combat(attackerRolls, defenderRolls, contestedArmies)
@@ -58,7 +58,7 @@ class CombatResolverTest {
     fun `Attacker can win more than one roll`() {
         val attackerRolls = listOf(6, 5)
         val defenderRolls = listOf(2, 1)
-        val contestedArmies = PositiveInt(2)
+        val contestedArmies = Pos(2)
 
         val (lostAttackerArmies, lostDefenderArmies) =
             resolver.combat(attackerRolls, defenderRolls, contestedArmies)
@@ -71,7 +71,7 @@ class CombatResolverTest {
     fun `Attacker rolls are sorted before evaluating the results`() {
         val attackerRolls = listOf(1, 6)
         val defenderRolls = listOf(2)
-        val contestedArmies = PositiveInt(1)
+        val contestedArmies = Pos(1)
 
         val (lostAttackerArmies, lostDefenderArmies) =
             resolver.combat(attackerRolls, defenderRolls, contestedArmies)
@@ -84,7 +84,7 @@ class CombatResolverTest {
     fun `Defender rolls are sorted before evaluating the results`() {
         val attackerRolls = listOf(6)
         val defenderRolls = listOf(2, 6)
-        val contestedArmies = PositiveInt(1)
+        val contestedArmies = Pos(1)
 
         val (lostAttackerArmies, lostDefenderArmies) =
             resolver.combat(attackerRolls, defenderRolls, contestedArmies)
@@ -97,7 +97,7 @@ class CombatResolverTest {
     fun `Attacker can't win more than the contested armies`() {
         val attackerRolls = listOf(6, 3)
         val defenderRolls = listOf(1, 5)
-        val contestedArmies = PositiveInt(1)
+        val contestedArmies = Pos(1)
 
         val (lostAttackerArmies, lostDefenderArmies) =
             resolver.combat(attackerRolls, defenderRolls, contestedArmies)
@@ -110,7 +110,7 @@ class CombatResolverTest {
     fun `Defender can't win more than the contested armies`() {
         val attackerRolls = listOf(1, 2)
         val defenderRolls = listOf(1, 5)
-        val contestedArmies = PositiveInt(1)
+        val contestedArmies = Pos(1)
 
         val (lostAttackerArmies, lostDefenderArmies) =
             resolver.combat(attackerRolls, defenderRolls, contestedArmies)
@@ -121,7 +121,7 @@ class CombatResolverTest {
 
     @Test
     fun `Can't contest more armies than the attacker's rolled dice`() {
-        val contested = PositiveInt(2)
+        val contested = Pos(2)
         val exception = assertFailsWith<TooManyArmiesContestedException> {
             resolver.combat(listOf(1), listOf(2, 3), contestedArmies = contested)
         }
@@ -130,7 +130,7 @@ class CombatResolverTest {
 
     @Test
     fun `Can't contest more armies than the defender's rolled dice`() {
-        val contested = PositiveInt(3)
+        val contested = Pos(3)
         val exception = assertFailsWith<TooManyArmiesContestedException> {
             resolver.combat(listOf(1, 2, 3, 4), listOf(1), contestedArmies = contested)
         }


### PR DESCRIPTION
Resolves combat between an attacker and a defender by comparing the dice rolls of each one.

We need to know which were the rolls to be able to show them to the player, so we can't isolate those in this class. The dice rolls are thus passed as parameters.