### PR TITLE
Creates PositiveInt

### DIFF
--- a/core/src/main/PositiveInt.kt
+++ b/core/src/main/PositiveInt.kt
@@ -21,14 +21,8 @@ class PositiveInt(private val value: Int) : Number(), Comparable<PositiveInt> {
     override operator fun compareTo(other: PositiveInt) = toInt().compareTo(other.toInt())
 
     operator fun plus(other: PositiveInt): PositiveInt {
-        return buildCheckingForOverflow {
-            PositiveInt(Math.addExact(toInt(), other.toInt()))
-        }
-    }
-
-    private fun buildCheckingForOverflow(builder: () -> PositiveInt): PositiveInt {
         try {
-            return builder()
+            return PositiveInt(Math.addExact(toInt(), other.toInt()))
         } catch (e: ArithmeticException) {
             throw PositiveIntOverflowException()
         }
@@ -43,8 +37,10 @@ class PositiveInt(private val value: Int) : Number(), Comparable<PositiveInt> {
     }
 
     operator fun times(other: PositiveInt): PositiveInt {
-        return buildCheckingForOverflow {
-            PositiveInt(Math.multiplyExact(toInt(), other.toInt()))
+        try {
+            return PositiveInt(Math.multiplyExact(toInt(), other.toInt()))
+        } catch (e: ArithmeticException) {
+            throw PositiveIntOverflowException()
         }
     }
 
@@ -53,8 +49,10 @@ class PositiveInt(private val value: Int) : Number(), Comparable<PositiveInt> {
     operator fun rem(other: PositiveInt) = PositiveInt(toInt() % other.toInt())
 
     operator fun inc(): PositiveInt {
-        return buildCheckingForOverflow {
-            PositiveInt(Math.incrementExact(toInt()))
+        try {
+            return PositiveInt(Math.incrementExact(toInt()))
+        } catch (e: ArithmeticException) {
+            throw PositiveIntOverflowException()
         }
     }
 

--- a/core/src/main/PositiveInt.kt
+++ b/core/src/main/PositiveInt.kt
@@ -18,7 +18,7 @@ class PositiveInt(private val value: Int) : Number(), Comparable<PositiveInt> {
     override fun toLong() = value.toLong()
     override fun toShort() = value.toShort()
 
-    override operator fun compareTo(other: PositiveInt) = value.compareTo(other.value)
+    override operator fun compareTo(other: PositiveInt) = toInt().compareTo(other.toInt())
 
     operator fun plus(other: PositiveInt): PositiveInt {
         return buildCheckingForOverflow {

--- a/core/src/main/PositiveInt.kt
+++ b/core/src/main/PositiveInt.kt
@@ -1,0 +1,60 @@
+class PositiveInt private constructor(
+    private val value: Int) : Number(), Comparable<PositiveInt> {
+
+    override fun toByte() = value.toByte()
+    override fun toChar() = value.toChar()
+    override fun toDouble() = value.toDouble()
+    override fun toFloat() = value.toFloat()
+    override fun toInt() = value
+    override fun toLong() = value.toLong()
+    override fun toShort() = value.toShort()
+
+    override operator fun compareTo(other: PositiveInt) = value.compareTo(other.value)
+
+    operator fun plus(other: PositiveInt) = fromInt(toInt() + other.toInt())
+
+    operator fun minus(other: PositiveInt): PositiveInt {
+        try {
+            return fromInt(toInt() - other.toInt())
+        } catch (e: NonPositiveNumberException) {
+            throw TooBigToSubtractException(this, other)
+        }
+    }
+
+    operator fun times(other: PositiveInt) = fromInt(toInt() * other.toInt())
+
+    operator fun div(other: PositiveInt) = fromInt(toInt() / other.toInt())
+
+    operator fun rem(other: PositiveInt) = fromInt(toInt() % other.toInt())
+
+    operator fun inc() = fromInt(value.inc())
+
+    operator fun dec(): PositiveInt {
+        try {
+            return fromInt(value.dec())
+        } catch (e: NonPositiveNumberException) {
+            throw CantDecrementException()
+        }
+    }
+
+    override fun equals(other: Any?): Boolean =
+        other is PositiveInt && toInt() == other.toInt()
+
+    override fun hashCode(): Int = toInt()
+
+    override fun toString() = "PositiveInt($value)"
+
+    companion object {
+
+        fun fromInt(number: Int): PositiveInt {
+            assertPositive(number)
+            return PositiveInt(number)
+        }
+
+        private fun assertPositive(number: Int) {
+            if (number <= 0) {
+                throw NonPositiveNumberException(number)
+            }
+        }
+    }
+}

--- a/core/src/main/PositiveInt.kt
+++ b/core/src/main/PositiveInt.kt
@@ -20,7 +20,19 @@ class PositiveInt(private val value: Int) : Number(), Comparable<PositiveInt> {
 
     override operator fun compareTo(other: PositiveInt) = value.compareTo(other.value)
 
-    operator fun plus(other: PositiveInt) = PositiveInt(toInt() + other.toInt())
+    operator fun plus(other: PositiveInt): PositiveInt {
+        return buildCheckingForOverflow {
+            PositiveInt(Math.addExact(toInt(), other.toInt()))
+        }
+    }
+
+    private fun buildCheckingForOverflow(builder: () -> PositiveInt): PositiveInt {
+        try {
+            return builder()
+        } catch (e: ArithmeticException) {
+            throw PositiveIntOverflowException()
+        }
+    }
 
     operator fun minus(other: PositiveInt): PositiveInt {
         try {
@@ -30,13 +42,21 @@ class PositiveInt(private val value: Int) : Number(), Comparable<PositiveInt> {
         }
     }
 
-    operator fun times(other: PositiveInt) = PositiveInt(toInt() * other.toInt())
+    operator fun times(other: PositiveInt): PositiveInt {
+        return buildCheckingForOverflow {
+            PositiveInt(Math.multiplyExact(toInt(), other.toInt()))
+        }
+    }
 
     operator fun div(other: PositiveInt) = PositiveInt(toInt() / other.toInt())
 
     operator fun rem(other: PositiveInt) = PositiveInt(toInt() % other.toInt())
 
-    operator fun inc() = PositiveInt(value.inc())
+    operator fun inc(): PositiveInt {
+        return buildCheckingForOverflow {
+            PositiveInt(Math.incrementExact(toInt()))
+        }
+    }
 
     operator fun dec(): PositiveInt {
         try {
@@ -52,4 +72,8 @@ class PositiveInt(private val value: Int) : Number(), Comparable<PositiveInt> {
     override fun hashCode(): Int = toInt()
 
     override fun toString() = "PositiveInt($value)"
+
+    companion object {
+        val MAX_VALUE: PositiveInt = PositiveInt(Int.MAX_VALUE)
+    }
 }

--- a/core/src/main/PositiveInt.kt
+++ b/core/src/main/PositiveInt.kt
@@ -1,5 +1,14 @@
-class PositiveInt private constructor(
-    private val value: Int) : Number(), Comparable<PositiveInt> {
+class PositiveInt(private val value: Int) : Number(), Comparable<PositiveInt> {
+
+    init {
+        assertPositive(value)
+    }
+
+    private fun assertPositive(number: Int) {
+        if (number <= 0) {
+            throw NonPositiveNumberException(number)
+        }
+    }
 
     override fun toByte() = value.toByte()
     override fun toChar() = value.toChar()
@@ -11,27 +20,27 @@ class PositiveInt private constructor(
 
     override operator fun compareTo(other: PositiveInt) = value.compareTo(other.value)
 
-    operator fun plus(other: PositiveInt) = fromInt(toInt() + other.toInt())
+    operator fun plus(other: PositiveInt) = PositiveInt(toInt() + other.toInt())
 
     operator fun minus(other: PositiveInt): PositiveInt {
         try {
-            return fromInt(toInt() - other.toInt())
+            return PositiveInt(toInt() - other.toInt())
         } catch (e: NonPositiveNumberException) {
             throw TooBigToSubtractException(this, other)
         }
     }
 
-    operator fun times(other: PositiveInt) = fromInt(toInt() * other.toInt())
+    operator fun times(other: PositiveInt) = PositiveInt(toInt() * other.toInt())
 
-    operator fun div(other: PositiveInt) = fromInt(toInt() / other.toInt())
+    operator fun div(other: PositiveInt) = PositiveInt(toInt() / other.toInt())
 
-    operator fun rem(other: PositiveInt) = fromInt(toInt() % other.toInt())
+    operator fun rem(other: PositiveInt) = PositiveInt(toInt() % other.toInt())
 
-    operator fun inc() = fromInt(value.inc())
+    operator fun inc() = PositiveInt(value.inc())
 
     operator fun dec(): PositiveInt {
         try {
-            return fromInt(value.dec())
+            return PositiveInt(value.dec())
         } catch (e: NonPositiveNumberException) {
             throw CantDecrementException()
         }
@@ -43,18 +52,4 @@ class PositiveInt private constructor(
     override fun hashCode(): Int = toInt()
 
     override fun toString() = "PositiveInt($value)"
-
-    companion object {
-
-        fun fromInt(number: Int): PositiveInt {
-            assertPositive(number)
-            return PositiveInt(number)
-        }
-
-        private fun assertPositive(number: Int) {
-            if (number <= 0) {
-                throw NonPositiveNumberException(number)
-            }
-        }
-    }
 }

--- a/core/src/main/PositiveIntExceptions.kt
+++ b/core/src/main/PositiveIntExceptions.kt
@@ -1,12 +1,15 @@
-class NonPositiveNumberException(val number: Number) : IllegalArgumentException(
+open class PositiveIntException(message: String) : Exception(message)
+
+class NonPositiveNumberException(val number: Number) : PositiveIntException(
     "Can't create a PositiveInt from non-positive number $number.")
 
 class TooBigToSubtractException(
     val minuend: PositiveInt, val subtrahend: PositiveInt
-) : IllegalArgumentException(
+) : PositiveIntException(
     "Can't do $minuend - $subtrahend, it would result in a non-positive number.")
 
-class CantDecrementException : Exception("Can't decrement a PositiveInt past 1.")
+class CantDecrementException : PositiveIntException(
+    "Can't decrement a PositiveInt past 1.")
 
-class PositiveIntOverflowException : ArithmeticException(
+class PositiveIntOverflowException : PositiveIntException(
     "This operation would result in a value greater than the maximum for PositiveInt.")

--- a/core/src/main/PositiveIntExceptions.kt
+++ b/core/src/main/PositiveIntExceptions.kt
@@ -1,0 +1,9 @@
+class NonPositiveNumberException(val number: Number) : IllegalArgumentException(
+    "Can't create a PositiveInt from non-positive number $number.")
+
+class TooBigToSubtractException(
+    val minuend: PositiveInt, val subtrahend: PositiveInt
+) : IllegalArgumentException(
+    "Can't do $minuend - $subtrahend, it would result in a non-positive number.")
+
+class CantDecrementException : Exception("Can't decrement a PositiveInt past 1.")

--- a/core/src/main/PositiveIntExceptions.kt
+++ b/core/src/main/PositiveIntExceptions.kt
@@ -7,3 +7,6 @@ class TooBigToSubtractException(
     "Can't do $minuend - $subtrahend, it would result in a non-positive number.")
 
 class CantDecrementException : Exception("Can't decrement a PositiveInt past 1.")
+
+class PositiveIntOverflowException : ArithmeticException(
+    "This operation would result in a value greater than the maximum for PositiveInt.")

--- a/core/src/test/PositiveIntTest.kt
+++ b/core/src/test/PositiveIntTest.kt
@@ -218,4 +218,35 @@ class PositiveIntTest {
         assertTrue(second in range)
         assertTrue(PositiveInt(3) in range)
     }
+    
+    @Test
+    fun `Can't increment past the maximum value`() {
+        var number = PositiveInt.MAX_VALUE
+
+        assertFailsWith<PositiveIntOverflowException> {
+            number++
+        }
+
+        assertEquals(number, PositiveInt.MAX_VALUE)
+    }
+
+    @Test
+    fun `Can't sum past the maximum value`() {
+        val first = PositiveInt.MAX_VALUE
+        val second = PositiveInt(1)
+
+        assertFailsWith<PositiveIntOverflowException> {
+            first + second
+        }
+    }
+
+    @Test
+    fun `Can't multiply past the maximum value`() {
+        val first = PositiveInt.MAX_VALUE
+        val second = PositiveInt.MAX_VALUE
+
+        assertFailsWith<PositiveIntOverflowException> {
+            first * second
+        }
+    }
 }

--- a/core/src/test/PositiveIntTest.kt
+++ b/core/src/test/PositiveIntTest.kt
@@ -1,0 +1,220 @@
+import kotlin.test.*
+
+class PositiveIntTest {
+
+    @Test
+    fun `Can't create from a negative Int`() {
+        val negative = -3
+
+        val exception = assertFailsWith<NonPositiveNumberException> {
+            PositiveInt.fromInt(negative)
+        }
+
+        assertEquals(negative, exception.number)
+    }
+    @Test
+    fun `Can't create from Int zero`() {
+        val zero = 0
+
+        val exception = assertFailsWith<NonPositiveNumberException> {
+            PositiveInt.fromInt(zero)
+        }
+
+        assertEquals(zero, exception.number)
+    }
+
+    @Test
+    fun `Two PositiveInts created with same Int are equal`() {
+        val first = PositiveInt.fromInt(23)
+        val second = PositiveInt.fromInt(23)
+        assertEquals(first, second)
+    }
+
+    @Test
+    fun `Two PositiveInts created with different Ints are different`() {
+        val first = PositiveInt.fromInt(322)
+        val second = PositiveInt.fromInt(1)
+        assertNotEquals(first, second)
+    }
+
+    @Test
+    fun `A PositiveInt is not equal to objects of other classes`() {
+        val first = PositiveInt.fromInt(32)
+        val second = Object()
+
+        assertNotEquals<Any>(first, second)
+    }
+
+    @Test
+    fun `toInt returns the Int with which it was created`() {
+        val integer = 2
+
+        val positiveInteger = PositiveInt.fromInt(integer)
+
+        assertEquals(integer, positiveInteger.toInt())
+    }
+
+    @Test
+    fun `toByte returns the toByte of the Int with which it was created`() {
+        val integer = 3
+
+        val positiveInteger = PositiveInt.fromInt(integer)
+
+        assertEquals(integer.toByte(), positiveInteger.toByte())
+    }
+
+    @Test
+    fun `toChar returns the toChar of the Int with which it was created`() {
+        val integer = 123
+
+        val positiveInteger = PositiveInt.fromInt(integer)
+
+        assertEquals(integer.toChar(), positiveInteger.toChar())
+    }
+
+    @Test
+    fun `toDouble returns the toDouble of the Int with which it was created`() {
+        val integer = 432
+
+        val positiveInteger = PositiveInt.fromInt(integer)
+
+        assertEquals(integer.toDouble(), positiveInteger.toDouble())
+    }
+
+    @Test
+    fun `toFloat returns the toFloat of the Int with which it was created`() {
+        val integer = 654
+
+        val positiveInteger = PositiveInt.fromInt(integer)
+
+        assertEquals(integer.toFloat(), positiveInteger.toFloat())
+    }
+
+    @Test
+    fun `toLong returns the toLong of the Int with which it was created`() {
+        val integer = 98765
+
+        val positiveInteger = PositiveInt.fromInt(integer)
+
+        assertEquals(integer.toLong(), positiveInteger.toLong())
+    }
+
+    @Test
+    fun `toShort returns the toShort of the Int with which it was created`() {
+        val integer = 13123
+
+        val positiveInteger = PositiveInt.fromInt(integer)
+
+        assertEquals(integer.toShort(), positiveInteger.toShort())
+    }
+
+    @Test
+    fun `compareTo returns the compareTo of the Int with which it was created`() {
+        val firstInt = 23
+        val secondInt = 12
+
+        val firstPositive = PositiveInt.fromInt(firstInt)
+        val secondPositive = PositiveInt.fromInt(secondInt)
+
+        assertTrue(firstPositive > secondPositive)
+    }
+
+    @Test
+    fun `Adding a PositiveInt with another PositiveInt returns the sum of them`() {
+        val first = PositiveInt.fromInt(23)
+        val second = PositiveInt.fromInt(7876)
+
+        val expected = first.toInt() + second.toInt()
+        assertEquals(expected, (first + second).toInt())
+    }
+    
+    @Test
+    fun `Subtracting a PositiveInt from another PositiveInt returns the difference`() {
+        val first = PositiveInt.fromInt(34)
+        val second = PositiveInt.fromInt(1)
+
+        val expected = first.toInt() - second.toInt()
+        assertEquals(expected, (first - second).toInt())
+    }
+
+    @Test
+    fun `Can't subtract a bigger or equal PositiveInt from a PositiveInt`() {
+        val first = PositiveInt.fromInt(42)
+        val second = PositiveInt.fromInt(98934)
+
+        val exception = assertFailsWith<TooBigToSubtractException> {
+            first - second
+        }
+
+        assertEquals(first, exception.minuend)
+        assertEquals(second, exception.subtrahend)
+    }
+
+    @Test
+    fun `times() multiplies the two PositiveInts`() {
+        val first = PositiveInt.fromInt(2)
+        val second = PositiveInt.fromInt(5)
+
+        val expected = PositiveInt.fromInt(10)
+        assertEquals(expected,first * second)
+    }
+
+    @Test
+    fun `div() divides the two PositiveInts`() {
+        val first = PositiveInt.fromInt(11)
+        val second = PositiveInt.fromInt(2)
+
+        val expected = PositiveInt.fromInt(5)
+        assertEquals(expected, first / second)
+    }
+
+    @Test
+    fun `rem() calculates the remainder between the two PositiveInts`() {
+        val first = PositiveInt.fromInt(4)
+        val second = PositiveInt.fromInt(3)
+
+        val expected = PositiveInt.fromInt(1)
+        assertEquals(expected, first % second)
+    }
+
+    @Test
+    fun `inc() increments the PositiveInt`() {
+        var number = PositiveInt.fromInt(23)
+
+        number++
+
+        val expected = PositiveInt.fromInt(24)
+        assertEquals(expected, number)
+    }
+
+    @Test
+    fun `dec() decrements the PositiveInt`() {
+        var number = PositiveInt.fromInt(43)
+
+        number--
+
+        val expected = PositiveInt.fromInt(42)
+        assertEquals(expected, number)
+    }
+
+    @Test
+    fun `Can't decrement PositiveInt from Int 1`() {
+        var number = PositiveInt.fromInt(1)
+
+        assertFailsWith<CantDecrementException> {
+            number--
+        }
+    }
+
+    @Test
+    fun `rangeTo() creates a range that corresponds to the same ComparableRange`() {
+        val first = PositiveInt.fromInt(1)
+        val second = PositiveInt.fromInt(5)
+
+        val range = first..second
+
+        assertTrue(first in range)
+        assertTrue(second in range)
+        assertTrue(PositiveInt.fromInt(3) in range)
+    }
+}

--- a/core/src/test/PositiveIntTest.kt
+++ b/core/src/test/PositiveIntTest.kt
@@ -7,17 +7,18 @@ class PositiveIntTest {
         val negative = -3
 
         val exception = assertFailsWith<NonPositiveNumberException> {
-            PositiveInt.fromInt(negative)
+            PositiveInt(negative)
         }
 
         assertEquals(negative, exception.number)
     }
+
     @Test
     fun `Can't create from Int zero`() {
         val zero = 0
 
         val exception = assertFailsWith<NonPositiveNumberException> {
-            PositiveInt.fromInt(zero)
+            PositiveInt(zero)
         }
 
         assertEquals(zero, exception.number)
@@ -25,21 +26,21 @@ class PositiveIntTest {
 
     @Test
     fun `Two PositiveInts created with same Int are equal`() {
-        val first = PositiveInt.fromInt(23)
-        val second = PositiveInt.fromInt(23)
+        val first = PositiveInt(23)
+        val second = PositiveInt(23)
         assertEquals(first, second)
     }
 
     @Test
     fun `Two PositiveInts created with different Ints are different`() {
-        val first = PositiveInt.fromInt(322)
-        val second = PositiveInt.fromInt(1)
+        val first = PositiveInt(322)
+        val second = PositiveInt(1)
         assertNotEquals(first, second)
     }
 
     @Test
     fun `A PositiveInt is not equal to objects of other classes`() {
-        val first = PositiveInt.fromInt(32)
+        val first = PositiveInt(32)
         val second = Object()
 
         assertNotEquals<Any>(first, second)
@@ -49,7 +50,7 @@ class PositiveIntTest {
     fun `toInt returns the Int with which it was created`() {
         val integer = 2
 
-        val positiveInteger = PositiveInt.fromInt(integer)
+        val positiveInteger = PositiveInt(integer)
 
         assertEquals(integer, positiveInteger.toInt())
     }
@@ -58,7 +59,7 @@ class PositiveIntTest {
     fun `toByte returns the toByte of the Int with which it was created`() {
         val integer = 3
 
-        val positiveInteger = PositiveInt.fromInt(integer)
+        val positiveInteger = PositiveInt(integer)
 
         assertEquals(integer.toByte(), positiveInteger.toByte())
     }
@@ -67,7 +68,7 @@ class PositiveIntTest {
     fun `toChar returns the toChar of the Int with which it was created`() {
         val integer = 123
 
-        val positiveInteger = PositiveInt.fromInt(integer)
+        val positiveInteger = PositiveInt(integer)
 
         assertEquals(integer.toChar(), positiveInteger.toChar())
     }
@@ -76,7 +77,7 @@ class PositiveIntTest {
     fun `toDouble returns the toDouble of the Int with which it was created`() {
         val integer = 432
 
-        val positiveInteger = PositiveInt.fromInt(integer)
+        val positiveInteger = PositiveInt(integer)
 
         assertEquals(integer.toDouble(), positiveInteger.toDouble())
     }
@@ -85,7 +86,7 @@ class PositiveIntTest {
     fun `toFloat returns the toFloat of the Int with which it was created`() {
         val integer = 654
 
-        val positiveInteger = PositiveInt.fromInt(integer)
+        val positiveInteger = PositiveInt(integer)
 
         assertEquals(integer.toFloat(), positiveInteger.toFloat())
     }
@@ -94,7 +95,7 @@ class PositiveIntTest {
     fun `toLong returns the toLong of the Int with which it was created`() {
         val integer = 98765
 
-        val positiveInteger = PositiveInt.fromInt(integer)
+        val positiveInteger = PositiveInt(integer)
 
         assertEquals(integer.toLong(), positiveInteger.toLong())
     }
@@ -103,7 +104,7 @@ class PositiveIntTest {
     fun `toShort returns the toShort of the Int with which it was created`() {
         val integer = 13123
 
-        val positiveInteger = PositiveInt.fromInt(integer)
+        val positiveInteger = PositiveInt(integer)
 
         assertEquals(integer.toShort(), positiveInteger.toShort())
     }
@@ -113,25 +114,25 @@ class PositiveIntTest {
         val firstInt = 23
         val secondInt = 12
 
-        val firstPositive = PositiveInt.fromInt(firstInt)
-        val secondPositive = PositiveInt.fromInt(secondInt)
+        val firstPositive = PositiveInt(firstInt)
+        val secondPositive = PositiveInt(secondInt)
 
         assertTrue(firstPositive > secondPositive)
     }
 
     @Test
     fun `Adding a PositiveInt with another PositiveInt returns the sum of them`() {
-        val first = PositiveInt.fromInt(23)
-        val second = PositiveInt.fromInt(7876)
+        val first = PositiveInt(23)
+        val second = PositiveInt(7876)
 
         val expected = first.toInt() + second.toInt()
         assertEquals(expected, (first + second).toInt())
     }
-    
+
     @Test
     fun `Subtracting a PositiveInt from another PositiveInt returns the difference`() {
-        val first = PositiveInt.fromInt(34)
-        val second = PositiveInt.fromInt(1)
+        val first = PositiveInt(34)
+        val second = PositiveInt(1)
 
         val expected = first.toInt() - second.toInt()
         assertEquals(expected, (first - second).toInt())
@@ -139,8 +140,8 @@ class PositiveIntTest {
 
     @Test
     fun `Can't subtract a bigger or equal PositiveInt from a PositiveInt`() {
-        val first = PositiveInt.fromInt(42)
-        val second = PositiveInt.fromInt(98934)
+        val first = PositiveInt(42)
+        val second = PositiveInt(98934)
 
         val exception = assertFailsWith<TooBigToSubtractException> {
             first - second
@@ -152,54 +153,54 @@ class PositiveIntTest {
 
     @Test
     fun `times() multiplies the two PositiveInts`() {
-        val first = PositiveInt.fromInt(2)
-        val second = PositiveInt.fromInt(5)
+        val first = PositiveInt(2)
+        val second = PositiveInt(5)
 
-        val expected = PositiveInt.fromInt(10)
+        val expected = PositiveInt(10)
         assertEquals(expected,first * second)
     }
 
     @Test
     fun `div() divides the two PositiveInts`() {
-        val first = PositiveInt.fromInt(11)
-        val second = PositiveInt.fromInt(2)
+        val first = PositiveInt(11)
+        val second = PositiveInt(2)
 
-        val expected = PositiveInt.fromInt(5)
+        val expected = PositiveInt(5)
         assertEquals(expected, first / second)
     }
 
     @Test
     fun `rem() calculates the remainder between the two PositiveInts`() {
-        val first = PositiveInt.fromInt(4)
-        val second = PositiveInt.fromInt(3)
+        val first = PositiveInt(4)
+        val second = PositiveInt(3)
 
-        val expected = PositiveInt.fromInt(1)
+        val expected = PositiveInt(1)
         assertEquals(expected, first % second)
     }
 
     @Test
     fun `inc() increments the PositiveInt`() {
-        var number = PositiveInt.fromInt(23)
+        var number = PositiveInt(23)
 
         number++
 
-        val expected = PositiveInt.fromInt(24)
+        val expected = PositiveInt(24)
         assertEquals(expected, number)
     }
 
     @Test
     fun `dec() decrements the PositiveInt`() {
-        var number = PositiveInt.fromInt(43)
+        var number = PositiveInt(43)
 
         number--
 
-        val expected = PositiveInt.fromInt(42)
+        val expected = PositiveInt(42)
         assertEquals(expected, number)
     }
 
     @Test
     fun `Can't decrement PositiveInt from Int 1`() {
-        var number = PositiveInt.fromInt(1)
+        var number = PositiveInt(1)
 
         assertFailsWith<CantDecrementException> {
             number--
@@ -208,13 +209,13 @@ class PositiveIntTest {
 
     @Test
     fun `rangeTo() creates a range that corresponds to the same ComparableRange`() {
-        val first = PositiveInt.fromInt(1)
-        val second = PositiveInt.fromInt(5)
+        val first = PositiveInt(1)
+        val second = PositiveInt(5)
 
         val range = first..second
 
         assertTrue(first in range)
         assertTrue(second in range)
-        assertTrue(PositiveInt.fromInt(3) in range)
+        assertTrue(PositiveInt(3) in range)
     }
 }


### PR DESCRIPTION
Because I was tired of putting `assertPositive` everywhere.

The idea is to change the `Int`s for `PositiveInt`s in classes that take values that must be positive.

I implemented every `Int` operation except for the unary operations, because doing `-PositiveInt.fromInt(2)` would not return another `PositiveInt`, and bit operations, because, well, we don't need them yet. 