### PR TITLE
Asset manager

### DIFF
--- a/core/src/main/screens/KamchatkaScreen.kt
+++ b/core/src/main/screens/KamchatkaScreen.kt
@@ -11,8 +11,8 @@ import com.badlogic.gdx.utils.viewport.Viewport
 abstract class KamchatkaScreen(
     private val game: Kamchatka
 ) : ScreenAdapter() {
-    abstract var viewport: Viewport
-    abstract var inputProcessor: InputProcessor
+    abstract val viewport: Viewport
+    abstract val inputProcessor: InputProcessor
 
     override fun render(delta: Float) {
         super.render(delta)

--- a/core/src/main/screens/ReadyScreen.kt
+++ b/core/src/main/screens/ReadyScreen.kt
@@ -12,8 +12,8 @@ import screens.running.RunningScreen
 
 class ReadyScreen(private val game: Kamchatka) : KamchatkaScreen(game) {
     private val message = BitmapFont()
-    override var viewport: Viewport = FitViewport(800F, 480F, game.camera)
-    override var inputProcessor: InputProcessor = object: InputAdapter() {
+    override val viewport: Viewport = FitViewport(800F, 480F, game.camera)
+    override val inputProcessor: InputProcessor = object: InputAdapter() {
         override fun keyDown(keycode: Int): Boolean {
             when (keycode) {
                 Input.Keys.Q -> Gdx.app.exit()

--- a/core/src/main/screens/running/CountrySelector.kt
+++ b/core/src/main/screens/running/CountrySelector.kt
@@ -1,15 +1,19 @@
 package screens.running
 
+import com.badlogic.gdx.assets.AssetManager
 import com.badlogic.gdx.graphics.Color
 import com.badlogic.gdx.graphics.Pixmap
 import com.badlogic.gdx.graphics.Texture
 
-class CountrySelector {
-    private val countryColorsMap: Texture = Texture("colores-paises.png")
+class CountrySelector(assetManager: AssetManager) {
+    private val countryColorsMap: Texture
     private val countryColorsPixmap: Pixmap
     private val mapColors = MapColors.fromJsonFile("mapa.json")
 
     init {
+        val countryColorsFileName = "colores-paises.png"
+        assetManager.load(countryColorsFileName, Texture::class.java)
+        countryColorsMap = assetManager.finishLoadingAsset<Texture>(countryColorsFileName)
         val textureData = countryColorsMap.textureData
         if (!textureData.isPrepared) {
             textureData.prepare()

--- a/core/src/main/screens/running/RunningScreen.kt
+++ b/core/src/main/screens/running/RunningScreen.kt
@@ -2,6 +2,7 @@ package screens.running
 
 import Kamchatka
 import com.badlogic.gdx.InputProcessor
+import com.badlogic.gdx.assets.AssetManager
 import com.badlogic.gdx.graphics.Texture
 import com.badlogic.gdx.scenes.scene2d.Stage
 import com.badlogic.gdx.utils.viewport.FitViewport
@@ -10,14 +11,23 @@ import screens.KamchatkaScreen
 
 
 class RunningScreen(game: Kamchatka) : KamchatkaScreen(game) {
-    private val worldmapTexture = Texture("mapa.png")
-    override var viewport: Viewport = FitViewport(
-        worldmapTexture.width.toFloat(),
-        worldmapTexture.height.toFloat(),
-        game.camera
-    )
-    private val stage: Stage = WorldmapStage(worldmapTexture, viewport)
-    override var inputProcessor: InputProcessor = stage
+    private val assetManager = AssetManager()
+    private val worldmapTexture: Texture
+    override val viewport: Viewport
+    private val stage: Stage
+    override val inputProcessor: InputProcessor
+
+    init {
+        assetManager.load("mapa.png", Texture::class.java)
+        worldmapTexture = assetManager.finishLoadingAsset<Texture>("mapa.png")
+        viewport = FitViewport(
+            worldmapTexture.width.toFloat(),
+            worldmapTexture.height.toFloat(),
+            game.camera
+        )
+        stage = WorldmapStage(worldmapTexture, viewport)
+        inputProcessor = stage
+    }
 
     override fun render(delta: Float) {
         super.render(delta)
@@ -28,7 +38,7 @@ class RunningScreen(game: Kamchatka) : KamchatkaScreen(game) {
 
     override fun dispose() {
         super.dispose()
-        worldmapTexture.dispose()
+        assetManager.dispose()
     }
 }
 

--- a/core/src/main/screens/running/RunningScreen.kt
+++ b/core/src/main/screens/running/RunningScreen.kt
@@ -18,14 +18,15 @@ class RunningScreen(game: Kamchatka) : KamchatkaScreen(game) {
     override val inputProcessor: InputProcessor
 
     init {
-        assetManager.load("mapa.png", Texture::class.java)
-        worldmapTexture = assetManager.finishLoadingAsset<Texture>("mapa.png")
+        val mapFileName = "mapa.png"
+        assetManager.load(mapFileName, Texture::class.java)
+        worldmapTexture = assetManager.finishLoadingAsset<Texture>(mapFileName)
         viewport = FitViewport(
             worldmapTexture.width.toFloat(),
             worldmapTexture.height.toFloat(),
             game.camera
         )
-        stage = WorldmapStage(worldmapTexture, viewport)
+        stage = WorldmapStage(assetManager, worldmapTexture, viewport)
         inputProcessor = stage
     }
 

--- a/core/src/main/screens/running/WorldmapStage.kt
+++ b/core/src/main/screens/running/WorldmapStage.kt
@@ -1,5 +1,6 @@
 package screens.running
 
+import com.badlogic.gdx.assets.AssetManager
 import com.badlogic.gdx.graphics.Color
 import com.badlogic.gdx.graphics.Texture
 import com.badlogic.gdx.graphics.g2d.BitmapFont
@@ -10,9 +11,9 @@ import com.badlogic.gdx.scenes.scene2d.ui.Image
 import com.badlogic.gdx.scenes.scene2d.ui.Label
 import com.badlogic.gdx.utils.viewport.Viewport
 
-class WorldmapStage(worldmapTexture: Texture, viewport: Viewport): Stage(viewport) {
+class WorldmapStage(assetManager: AssetManager, worldmapTexture: Texture, viewport: Viewport): Stage(viewport) {
     private val countryLabel = Label("", Label.LabelStyle(BitmapFont(), Color.WHITE))
-    private val countrySelector = CountrySelector()
+    private val countrySelector = CountrySelector(assetManager)
     private var currentCountry: String? = null
 
     init {


### PR DESCRIPTION
Para no tener que disposear de cada `Texture` de forma separada.
Antes no estábamos llamando `.dispose()` a la `Texture` del `CountrySelector`; esto arregla eso también.