### PR TITLE
GameInfo

### DIFF
--- a/core/src/main/gamelogic/GameInfo.kt
+++ b/core/src/main/gamelogic/GameInfo.kt
@@ -1,0 +1,12 @@
+package gamelogic
+
+import gamelogic.map.PoliticalMap
+import gamelogic.occupations.CountryOccupations
+
+data class GameInfo(
+    val players: List<PlayerInfo>,
+    val playerIterator: LoopingIterator<PlayerInfo>,
+    val politicalMap: PoliticalMap,
+    val occupations: CountryOccupations,
+    val destroyedPlayers: PlayerDestructions
+)

--- a/core/src/main/gamelogic/PlayerDestructions.kt
+++ b/core/src/main/gamelogic/PlayerDestructions.kt
@@ -1,0 +1,26 @@
+package gamelogic
+
+import Player
+
+class PlayerDestructions {
+    private var destroyed: MutableMap<Player, Player> = mutableMapOf()
+
+    fun isDestroyed(player: Player) = player in destroyed
+
+    fun destroy(destroyed: Player, destroyer: Player) {
+        assertPlayerIsNotDestroyed(destroyed)
+        this.destroyed[destroyed] = destroyer
+    }
+
+    private fun assertPlayerIsNotDestroyed(player: Player) {
+        if (player in destroyed) {
+            throw PlayerAlreadyDestroyedException(player)
+        }
+    }
+
+    fun destroyerOf(player: Player) = destroyed.getValue(player)
+}
+
+
+class PlayerAlreadyDestroyedException(val player: Player) :
+    Exception("Player $player is already destroyed.")

--- a/core/src/main/gamelogic/PlayerInfo.kt
+++ b/core/src/main/gamelogic/PlayerInfo.kt
@@ -3,7 +3,7 @@ package gamelogic
 enum class Color{White, Black, Red, Blue, Green, Yellow, Brown, Gray}
 
 class PlayerInfo(val name: String, val color:Color, val goal: Goal) {
-    fun reachedTheGoal(referee:Referee) : Boolean{
-        return goal.achieved(this, referee)
+    fun reachedTheGoal(gameInfo: GameInfo) : Boolean{
+        return goal.achieved(this, gameInfo)
     }
 }

--- a/core/src/test/gamelogic/GoalTest.kt
+++ b/core/src/test/gamelogic/GoalTest.kt
@@ -1,0 +1,149 @@
+package gamelogic
+
+import Player
+import PositiveInt
+import gamelogic.map.Continent
+import gamelogic.map.PoliticalMap
+import gamelogic.occupations.CountryOccupations
+import gamelogic.occupations.Occupation
+import org.junit.Test
+import kotlin.test.assertFails
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+private const val A_COUNTRY = "Argentina"
+private val SINGLE_COUNTRY_CONTINENT = Continent("América", setOf(A_COUNTRY))
+private val SINGLE_COUNTRY_POLITICAL_MAP =
+    PoliticalMap.Builder().addContinent(SINGLE_COUNTRY_CONTINENT).build()
+private val SINGLE_COUNTRY_OCCUPATIONS =
+    CountryOccupations(listOf(Occupation(A_COUNTRY, "Nico", PositiveInt(1))))
+
+private fun twoPlayersWithGoals(firstGoal: Goal, secondGoal: Goal) =
+    mutableListOf(
+        PlayerInfo("Eric", Color.White, firstGoal),
+        PlayerInfo("Nico", Color.White, secondGoal)
+    )
+
+private fun createSingleCountryGameInfo(
+    players: MutableList<PlayerInfo>, destroyed: PlayerDestructions = PlayerDestructions()
+) =
+    createGameInfo(
+        players, SINGLE_COUNTRY_POLITICAL_MAP, SINGLE_COUNTRY_OCCUPATIONS, destroyed)
+
+private fun createGameInfo(
+    players: MutableList<PlayerInfo>,
+    politicalMap: PoliticalMap,
+    occupations: CountryOccupations,
+    destroyed: PlayerDestructions = PlayerDestructions()
+) = GameInfo(players, players.loopingIterator(), politicalMap, occupations, destroyed)
+
+class OccupyContinentTest {
+    private val goal: Goal = Goal(listOf(OccupyContinent(SINGLE_COUNTRY_CONTINENT)))
+    private val notOccupierInfo: PlayerInfo
+    private val occupierInfo: PlayerInfo
+    private val gameInfo: GameInfo
+
+    init {
+        val players = twoPlayersWithGoals(goal, goal)
+        notOccupierInfo = players[0]
+        occupierInfo = players[1]
+        gameInfo = createSingleCountryGameInfo(players)
+    }
+
+    @Test
+    fun `Is not achieved when there's at least one country not occupied by the player`() {
+        assertFalse(goal.achieved(notOccupierInfo, gameInfo))
+    }
+
+    @Test
+    fun `Is achieved when all countries are occupied by the player`() {
+        assertTrue(goal.achieved(occupierInfo, gameInfo))
+    }
+}
+
+class OccupySubContinentTest {
+    @Test
+    fun `Can't create goal with more countries to occupy than the amount there are in the Continent`() {
+        assertFails {
+            singleCountryContinentGoalWithCountries(2)
+        }
+    }
+
+    @Test
+    fun `Is not achieved when there are still countries to be occupied`() {
+        val goal = singleCountryContinentGoalWithCountries(1)
+        val players = twoPlayersWithGoals(goal, goal)
+        val gameInfo = createSingleCountryGameInfo(players)
+        val notOccupierInfo = players[0]
+
+        assertFalse(goal.achieved(notOccupierInfo, gameInfo))
+    }
+
+    @Test
+    fun `Is achieved when all countries in the Continent are occupied`() {
+        val goal = singleCountryContinentGoalWithCountries(1)
+        val players = twoPlayersWithGoals(goal, goal)
+        val gameInfo = createSingleCountryGameInfo(players)
+        val occupierInfo = players[1]
+
+        assertTrue(goal.achieved(occupierInfo, gameInfo))
+    }
+
+    @Test
+    fun `Is achieved when there are countries left in the Continent to occupy but all the necessary countries are occupied`() {
+        val firstCountry = "Argentina"
+        val secondCountry = "Chile"
+        val continent = Continent("América", setOf(firstCountry, secondCountry))
+        val politicalMap = PoliticalMap.Builder().addContinent(continent).build()
+        val goal = Goal(listOf(OccupySubContinent(continent, 1)))
+        val players = twoPlayersWithGoals(goal, goal)
+        val occupations = CountryOccupations(
+            listOf(
+                Occupation(firstCountry, players[0].name, PositiveInt(1)),
+                Occupation(secondCountry, players[1].name, PositiveInt(1))
+            ))
+        val gameInfo = createGameInfo(players, politicalMap, occupations)
+
+        assertTrue(goal.achieved(players[0], gameInfo))
+    }
+
+    private fun singleCountryContinentGoalWithCountries(countries: Int) =
+        Goal(listOf(OccupySubContinent(SINGLE_COUNTRY_CONTINENT, countries)))
+}
+
+class DestroyTest {
+    @Test
+    fun `Is not achieved if the playerToDestroy is still in the game`() {
+        val playerToDestroy = "Nico"
+        val goal = Goal(listOf(Destroy(playerToDestroy)))
+        val players = twoPlayersWithGoals(goal, goal)
+        val gameInfo = createSingleCountryGameInfo(players)
+
+        assertFalse(goal.achieved(players[0], gameInfo))
+    }
+
+    @Test
+    fun `Is achieved if the playerToDestroy is destroyed by the player`() {
+        val playerToDestroy = "Eric"
+        val goal = Goal(listOf(Destroy(playerToDestroy)))
+        val players = twoPlayersWithGoals(goal, goal)
+        val destructions = PlayerDestructions()
+        destructions.destroy(playerToDestroy, players[1].name)
+        val gameInfo = createSingleCountryGameInfo(players, destructions)
+
+        assertTrue(goal.achieved(players[1], gameInfo))
+    }
+
+    @Test
+    fun `Is not achieved if the playerToDestroy is destroyed by another player`() {
+        val playerToDestroy = "Eric"
+        val goal = Goal(listOf(Destroy(playerToDestroy)))
+        val players = twoPlayersWithGoals(goal, goal)
+        val destructions = PlayerDestructions()
+        destructions.destroy(playerToDestroy, "Cristel")
+        val gameInfo = createSingleCountryGameInfo(players, destructions)
+
+        assertFalse(goal.achieved(players[1], gameInfo))
+    }
+}
+

--- a/core/src/test/gamelogic/PlayerDestructionsTest.kt
+++ b/core/src/test/gamelogic/PlayerDestructionsTest.kt
@@ -1,0 +1,86 @@
+package gamelogic
+
+import org.junit.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class PlayerDestructionsTest {
+    @Test
+    fun `No player isDestroyed in the beginning`() {
+        val destructions = PlayerDestructions()
+
+        assertFalse(destructions.isDestroyed("Eric"))
+    }
+
+    @Test
+    fun `Destroyed player isDestroyed`() {
+        val destructions = PlayerDestructions()
+
+        val destroyed = "Eric"
+        val destroyer = "Nico"
+        destructions.destroy(destroyed, destroyer)
+
+        assertTrue(destructions.isDestroyed(destroyed))
+        assertEquals(destroyer, destructions.destroyerOf(destroyed))
+    }
+
+    @Test
+    fun `Destroying one player doesn't destroy all others`() {
+        val destructions = PlayerDestructions()
+
+        destructions.destroy("Eric", "Nico")
+
+        assertFalse(destructions.isDestroyed("Nico"))
+    }
+
+    @Test
+    fun `Can destroy more than one player`() {
+        val destructions = PlayerDestructions()
+
+        val playersDestroyed = listOf("Eric", "Cristel")
+        val destroyer = "Nico"
+        playersDestroyed.forEach { destructions.destroy(it, destroyer) }
+
+        playersDestroyed.forEach {
+            assertTrue(destructions.isDestroyed(it))
+            assertEquals(destroyer, destructions.destroyerOf(it))
+        }
+    }
+
+    @Test
+    fun `destroyerOf players destroyed by different destroyed return the corresponding destroyers`() {
+        val destructions = PlayerDestructions()
+
+        val playersDestroyed = listOf("Eric", "Cristel")
+        val destroyers = listOf("Nico", "Eric")
+        val destroyedWithDestroyers = playersDestroyed.zip(destroyers)
+        destroyedWithDestroyers.forEach { (destroyed, destroyer) ->
+            destructions.destroy(destroyed, destroyer)
+        }
+
+        destroyedWithDestroyers.forEach { (destroyed, destroyer) ->
+            assertTrue(destructions.isDestroyed(destroyed))
+            assertEquals(destroyer, destructions.destroyerOf(destroyed))
+        }
+    }
+
+    @Test
+    fun `Can't destroy the same player twice`() {
+        val destructions = PlayerDestructions()
+
+        val destroyed = "Eric"
+        val destroyer = "Nico"
+        destructions.destroy(destroyed, destroyer)
+
+        val exception = assertFailsWith<PlayerAlreadyDestroyedException> {
+            destructions.destroy(destroyed, "Cristel")
+        }
+
+        assertEquals(destroyed, exception.player)
+        assertTrue(destructions.isDestroyed(destroyed))
+        assertEquals(destroyer, destructions.destroyerOf(destroyed))
+    }
+}
+

--- a/core/src/test/gamelogic/RefereeTest.kt
+++ b/core/src/test/gamelogic/RefereeTest.kt
@@ -88,8 +88,8 @@ class RefereeTest {
     @Test
     fun `AddArmies adds armies and changes referee's state`() {
         val armiesToAdd = PositiveInt(1)
-        val reinforcements = listOf(CountryReinforcement(arg,armiesToAdd) )
-        val  armiesBefore = sampleReferee.occupations.armiesOf(arg)
+        val reinforcements = listOf(CountryReinforcement(arg,armiesToAdd))
+        val armiesBefore = sampleReferee.occupations.armiesOf(arg)
         sampleReferee.addArmies(reinforcements)
         assertEquals(sampleReferee.currentState, Referee.State.Attack)
         assertEquals(sampleReferee.occupations.armiesOf(arg), armiesBefore + armiesToAdd)
@@ -120,7 +120,7 @@ class RefereeTest {
         val reinforcements = listOf(CountryReinforcement(arg, PositiveInt(3)))
         referee.addArmies(reinforcements)
         referee.endAttack()
-        referee.regroup(listOf(Regrouping(arg, chi, PositiveInt(2), referee)))
+        referee.regroup(listOf(Regrouping(arg, chi, PositiveInt(2))))
         assertEquals(referee.occupations.armiesOf(chi), PositiveInt(3))
         assertEquals(referee.currentState, Referee.State.AddArmies)
         assertEquals(referee.currentPlayer, eric)


### PR DESCRIPTION
Le pasa `GameInfo` a las `Goal`s y las otras clases adjuntas a `Referee` para poder hacer las cosas de `Referee` `private`.

Me quedaron en `public` las `CountryOccupations`, lo cual es todavía un poco feo. Habría que convertirlas en un objeto inmutable y devolver eso, así sólo el `Referee` puede tocar las `Occupation`s.