### PR TITLE
Refactor Referee

### DIFF
--- a/core/src/main/gamelogic/CountriesAreNotBorderingException.kt
+++ b/core/src/main/gamelogic/CountriesAreNotBorderingException.kt
@@ -1,0 +1,14 @@
+package gamelogic
+
+import Country
+import gamelogic.map.PoliticalMap
+
+class CountriesAreNotBorderingException(val from: Country, val to: Country) :
+    Exception("Countries $from and $to are not bordering.")
+{
+    fun assertAreBorderingIn(politicalMap: PoliticalMap) {
+        if (!politicalMap.areBordering(from, to)) {
+            throw this
+        }
+    }
+}

--- a/core/src/main/gamelogic/CountryIsNotOccupiedByPlayerException.kt
+++ b/core/src/main/gamelogic/CountryIsNotOccupiedByPlayerException.kt
@@ -1,0 +1,15 @@
+package gamelogic
+
+import Country
+import Player
+import gamelogic.occupations.CountryOccupations
+
+class CountryIsNotOccupiedByPlayerException(val country: Country, val player: Player) :
+    Exception("Country $country is not occupied by $player.")
+{
+    fun assertPlayerOccupiesCountryIn(occupations: CountryOccupations) {
+        if (occupations.occupierOf(country) != player) {
+            throw this
+        }
+    }
+}

--- a/core/src/main/gamelogic/CountryReinforcement.kt
+++ b/core/src/main/gamelogic/CountryReinforcement.kt
@@ -1,0 +1,14 @@
+package gamelogic
+
+import Country
+import Player
+import PositiveInt
+import gamelogic.occupations.CountryOccupations
+
+class CountryReinforcement(val country: Country, val armies: PositiveInt) {
+    fun apply(player: Player, occupations: CountryOccupations) {
+        CountryIsNotOccupiedByPlayerException(country, player)
+            .assertPlayerOccupiesCountryIn(occupations)
+        occupations.addArmies(country, armies)
+    }
+}

--- a/core/src/main/gamelogic/GameInfo.kt
+++ b/core/src/main/gamelogic/GameInfo.kt
@@ -2,20 +2,20 @@ package gamelogic
 
 import gamelogic.combat.AttackerFactory
 import gamelogic.gameState.GameState
-import gamelogic.gameState.NoState
+import gamelogic.gameState.ReinforceState
 import gamelogic.map.PoliticalMap
 import gamelogic.occupations.CountryOccupations
 import gamelogic.occupations.dealers.OccupationsDealer
 
 class GameInfo(
-    val attackerFactory: AttackerFactory,
     val players: MutableList<PlayerInfo>,
     val politicalMap: PoliticalMap,
     occupationsDealer: OccupationsDealer,
-    val destroyedPlayers: PlayerDestructions = PlayerDestructions(),
-    var state: GameState = NoState
+    val attackerFactory: AttackerFactory,
+    val destroyedPlayers: PlayerDestructions = PlayerDestructions()
 ) {
 
+    var state: GameState = ReinforceState(this)
     val playerIterator = players.loopingIterator()
     val occupations = CountryOccupations(occupationsDealer.dealTo(players.map { it.name }))
 

--- a/core/src/main/gamelogic/GameInfo.kt
+++ b/core/src/main/gamelogic/GameInfo.kt
@@ -11,8 +11,8 @@ class GameInfo(
     val attackerFactory: AttackerFactory,
     val players: MutableList<PlayerInfo>,
     val politicalMap: PoliticalMap,
-    val destroyedPlayers: PlayerDestructions,
     occupationsDealer: OccupationsDealer,
+    val destroyedPlayers: PlayerDestructions = PlayerDestructions(),
     var state: GameState = NoState
 ) {
 

--- a/core/src/main/gamelogic/GameInfo.kt
+++ b/core/src/main/gamelogic/GameInfo.kt
@@ -4,17 +4,19 @@ import gamelogic.combat.AttackerFactory
 import gamelogic.gameState.GameState
 import gamelogic.map.PoliticalMap
 import gamelogic.occupations.CountryOccupations
+import gamelogic.occupations.dealers.OccupationsDealer
 
-data class GameInfo(
+class GameInfo(
     var state: GameState,
     val attackerFactory: AttackerFactory,
     val players: MutableList<PlayerInfo>,
     val politicalMap: PoliticalMap,
-    val occupations: CountryOccupations,
-    val destroyedPlayers: PlayerDestructions
+    val destroyedPlayers: PlayerDestructions,
+    occupationsDealer: OccupationsDealer
 ) {
 
     val playerIterator = players.loopingIterator()
+    val occupations = CountryOccupations(occupationsDealer.dealTo(players.map { it.name }))
 
     val currentPlayer
         get() = playerIterator.current

--- a/core/src/main/gamelogic/GameInfo.kt
+++ b/core/src/main/gamelogic/GameInfo.kt
@@ -7,6 +7,12 @@ import gamelogic.map.PoliticalMap
 import gamelogic.occupations.CountryOccupations
 import gamelogic.occupations.dealers.OccupationsDealer
 
+/**
+ * Maintains the current game context, including its state, its current player,
+ * its occupations, etc.
+ *
+ * [GameState] objects manipulate this to advance the game.
+ */
 class GameInfo(
     val players: MutableList<PlayerInfo>,
     val politicalMap: PoliticalMap,

--- a/core/src/main/gamelogic/GameInfo.kt
+++ b/core/src/main/gamelogic/GameInfo.kt
@@ -2,17 +2,18 @@ package gamelogic
 
 import gamelogic.combat.AttackerFactory
 import gamelogic.gameState.GameState
+import gamelogic.gameState.NoState
 import gamelogic.map.PoliticalMap
 import gamelogic.occupations.CountryOccupations
 import gamelogic.occupations.dealers.OccupationsDealer
 
 class GameInfo(
-    var state: GameState,
     val attackerFactory: AttackerFactory,
     val players: MutableList<PlayerInfo>,
     val politicalMap: PoliticalMap,
     val destroyedPlayers: PlayerDestructions,
-    occupationsDealer: OccupationsDealer
+    occupationsDealer: OccupationsDealer,
+    var state: GameState = NoState
 ) {
 
     val playerIterator = players.loopingIterator()

--- a/core/src/main/gamelogic/GameInfo.kt
+++ b/core/src/main/gamelogic/GameInfo.kt
@@ -1,12 +1,20 @@
 package gamelogic
 
+import gamelogic.combat.AttackerFactory
 import gamelogic.map.PoliticalMap
 import gamelogic.occupations.CountryOccupations
 
 data class GameInfo(
+    var state: GameState,
+    val attackerFactory: AttackerFactory,
     val players: List<PlayerInfo>,
     val playerIterator: LoopingIterator<PlayerInfo>,
     val politicalMap: PoliticalMap,
     val occupations: CountryOccupations,
     val destroyedPlayers: PlayerDestructions
-)
+) {
+    val currentPlayer
+        get() = playerIterator.current
+
+    fun nextTurn() = playerIterator.next()
+}

--- a/core/src/main/gamelogic/GameInfo.kt
+++ b/core/src/main/gamelogic/GameInfo.kt
@@ -1,6 +1,7 @@
 package gamelogic
 
 import gamelogic.combat.AttackerFactory
+import gamelogic.gameState.GameState
 import gamelogic.map.PoliticalMap
 import gamelogic.occupations.CountryOccupations
 

--- a/core/src/main/gamelogic/GameInfo.kt
+++ b/core/src/main/gamelogic/GameInfo.kt
@@ -8,12 +8,14 @@ import gamelogic.occupations.CountryOccupations
 data class GameInfo(
     var state: GameState,
     val attackerFactory: AttackerFactory,
-    val players: List<PlayerInfo>,
-    val playerIterator: LoopingIterator<PlayerInfo>,
+    val players: MutableList<PlayerInfo>,
     val politicalMap: PoliticalMap,
     val occupations: CountryOccupations,
     val destroyedPlayers: PlayerDestructions
 ) {
+
+    val playerIterator = players.loopingIterator()
+
     val currentPlayer
         get() = playerIterator.current
 

--- a/core/src/main/gamelogic/GameState.kt
+++ b/core/src/main/gamelogic/GameState.kt
@@ -1,22 +1,105 @@
 package gamelogic
 
-enum class GameState {
-    AddArmies {
-        override fun next(gameInfo: GameInfo): GameState {
-            return Attack
-        }
-    },
-    Attack {
-        override fun next(gameInfo: GameInfo): GameState {
-            return Regroup
-        }
-    },
-    Regroup {
-        override fun next(gameInfo: GameInfo): GameState {
-            gameInfo.playerIterator.next()
-            return AddArmies
-        }
-    };
+import Country
+import PositiveInt
+import gamelogic.combat.Occupier
+import gamelogic.situations.classicCombat.ClassicCombatDiceAmountCalculator
 
-    abstract fun next(gameInfo: GameInfo): GameState
+sealed class GameState {
+    open fun addArmies(reinforcements: Collection<CountryReinforcement>): Unit =
+        throw NotInReinforcingStageException()
+
+    open fun makeAttack(from: Country, to: Country): Unit =
+        throw Exception("Cannot attack when not in attacking state")
+
+    open fun occupyConqueredCountry(armies: PositiveInt): Unit =
+        throw Exception("Cannot occupy when not in attacking state")
+
+    open fun endAttack(): Unit = throw Exception("Cannot end attack if not attacking")
+
+    open fun regroup(regroupings: List<Regrouping>): Unit =
+        throw Exception("Cannot regroup if not regrouping")
+}
+
+object NoState : GameState()
+
+class ReinforceState(private val gameInfo: GameInfo) : GameState() {
+    override fun addArmies(reinforcements: Collection<CountryReinforcement>) {
+        reinforcements.forEach {
+            it.apply(gameInfo.playerIterator.current.name, gameInfo.occupations)
+        }
+        gameInfo.state = AttackState(gameInfo)
+    }
+}
+
+class AttackState(private val gameInfo: GameInfo) : GameState() {
+    enum class AttackState { Fight, Occupation }
+    private var attackState = AttackState.Fight
+    private val occupier = Occupier(gameInfo.occupations)
+    private var occupyingFrom: Country? = null
+    private var occupyingTo: Country? = null
+
+
+    override fun makeAttack(from: Country, to: Country) {
+        if (attackState != AttackState.Fight) {
+            throw Exception("Cannot attack if not fighting")
+        }
+        val occupations = gameInfo.occupations
+        val currentPlayerName = gameInfo.currentPlayer.name
+        if (occupations.occupierOf(from) != currentPlayerName) {
+            throw Exception("Player $currentPlayerName does not occupy $from")
+        }
+        val politicalMap = gameInfo.politicalMap
+        CountriesAreNotBorderingException(from, to).assertAreBorderingIn(politicalMap)
+        val attacker = gameInfo.attackerFactory.create(
+            occupations, ClassicCombatDiceAmountCalculator()
+        )
+        attacker.attack(from, to)
+        if (occupations.isEmpty(to)) {
+            attackState = AttackState.Occupation
+            occupyingFrom = from
+            occupyingTo = to
+        }
+    }
+
+    override fun occupyConqueredCountry(armies: PositiveInt) {
+        if (attackState != AttackState.Occupation) {
+            throw Exception("Not the moment to occupy conquered country")
+        }
+
+        occupier.occupy(occupyingFrom!!, occupyingTo!!, armies)
+        attackState = AttackState.Fight
+    }
+
+    override fun endAttack() {
+        gameInfo.state = RegroupState(gameInfo)
+    }
+}
+
+class RegroupState(private val gameInfo: GameInfo) : GameState() {
+    override fun regroup(regroupings: List<Regrouping>) {
+        validateRegroupings(regroupings)
+        regroupings.map { it.apply(gameInfo.occupations) }
+        gameInfo.nextTurn()
+        gameInfo.state = ReinforceState(gameInfo)
+    }
+
+    private fun validateRegroupings(regroupings: List<Regrouping>) {
+        regroupings.forEach { it.validate(gameInfo) }
+        val occupations = gameInfo.occupations
+        val playerName = gameInfo.currentPlayer.name
+        if (
+            regroupings.any {
+                occupations.occupierOf(it.from) != playerName ||
+                occupations.occupierOf(it.to) != playerName
+            }
+        ) {
+            throw Exception("player must occupy both countries to regroup")
+        }
+
+        if (regroupings.distinctBy { it.from }.count() != regroupings.count()) {
+            throw Exception(
+                "Only one regroup per country per turn is allowed (to facilitate validation)")
+        }
+    }
 }

--- a/core/src/main/gamelogic/GameState.kt
+++ b/core/src/main/gamelogic/GameState.kt
@@ -103,3 +103,5 @@ class RegroupState(private val gameInfo: GameInfo) : GameState() {
         }
     }
 }
+
+class NotInReinforcingStageException : Exception("Cannot add armies right now.")

--- a/core/src/main/gamelogic/GameState.kt
+++ b/core/src/main/gamelogic/GameState.kt
@@ -1,0 +1,22 @@
+package gamelogic
+
+enum class GameState {
+    AddArmies {
+        override fun next(gameInfo: GameInfo): GameState {
+            return Attack
+        }
+    },
+    Attack {
+        override fun next(gameInfo: GameInfo): GameState {
+            return Regroup
+        }
+    },
+    Regroup {
+        override fun next(gameInfo: GameInfo): GameState {
+            gameInfo.playerIterator.next()
+            return AddArmies
+        }
+    };
+
+    abstract fun next(gameInfo: GameInfo): GameState
+}

--- a/core/src/main/gamelogic/Referee.kt
+++ b/core/src/main/gamelogic/Referee.kt
@@ -6,40 +6,10 @@ import PositiveInt
 import gamelogic.combat.AttackerFactory
 import gamelogic.combat.DiceRollingAttackerFactory
 import gamelogic.gameState.GameState
-import gamelogic.gameState.ReinforceState
 import gamelogic.map.PoliticalMap
-import gamelogic.occupations.CountryOccupations
 import gamelogic.occupations.dealers.OccupationsDealer
 import gamelogic.occupations.dealers.RandomOccupationsDealer
 
-class CountryReinforcement(val country:Country, val armies: PositiveInt) {
-    fun apply(player: Player, occupations: CountryOccupations) {
-        CountryIsNotOccupiedByPlayerException(country, player)
-            .assertPlayerOccupiesCountryIn(occupations)
-        occupations.addArmies(country, armies)
-    }
-}
-
-/**
- * preconditions (checked in [Referee.validateRegroupings] method):
- *      1. `regroupings.distinctBy { it.from }.count() == regroupings.count()`
- *      2. occupier of from and to is the same as the currentPlayer
- */
-class Regrouping(val from: Country, val to: Country, val armies: PositiveInt) {
-    fun validate(gameInfo: GameInfo) {
-        if (gameInfo.occupations.armiesOf(from) <= armies.toInt()) {
-            throw Exception(
-                "Cannot move ${armies.toInt()} armies if they are not available in country")
-        }
-        CountriesAreNotBorderingException(from, to)
-            .assertAreBorderingIn(gameInfo.politicalMap)
-    }
-
-    fun apply(occupations: CountryOccupations) {
-        occupations.removeArmies(from, armies)
-        occupations.addArmies(to, armies)
-    }
-}
 /**
  * The Referee of the game
  *

--- a/core/src/main/gamelogic/Referee.kt
+++ b/core/src/main/gamelogic/Referee.kt
@@ -67,7 +67,7 @@ class Referee(
 
     private val gameInfo = GameInfo(
         NoState, attackerFactory,
-        players, players.loopingIterator(), politicalMap, occupations,
+        players, politicalMap, occupations,
         PlayerDestructions()
     )
 

--- a/core/src/main/gamelogic/Referee.kt
+++ b/core/src/main/gamelogic/Referee.kt
@@ -14,9 +14,8 @@ import gamelogic.occupations.dealers.RandomOccupationsDealer
 
 class CountryReinforcement(val country:Country, val armies: PositiveInt) {
     fun apply(player: Player, occupations: CountryOccupations) {
-        if (occupations.occupierOf(country) != player) {
-            throw Exception("Player $player cannot add army to country")
-        }
+        CountryIsNotOccupiedByPlayerException(country, player)
+            .assertPlayerOccupiesCountryIn(occupations)
         occupations.addArmies(country, armies)
     }
 }

--- a/core/src/main/gamelogic/Referee.kt
+++ b/core/src/main/gamelogic/Referee.kt
@@ -63,9 +63,7 @@ class Referee(
 ) {
 
     private val gameInfo = GameInfo(
-        attackerFactory,
-        players, politicalMap,
-        PlayerDestructions(), occupationsDealer
+        attackerFactory, players, politicalMap, occupationsDealer
     )
 
     val occupations

--- a/core/src/main/gamelogic/Referee.kt
+++ b/core/src/main/gamelogic/Referee.kt
@@ -62,14 +62,15 @@ class Referee(
     attackerFactory: AttackerFactory = DiceRollingAttackerFactory()
 ) {
 
-    val occupations =
-        CountryOccupations(occupationsDealer.dealTo(players.map { it.name }))
 
     private val gameInfo = GameInfo(
         NoState, attackerFactory,
-        players, politicalMap, occupations,
-        PlayerDestructions()
+        players, politicalMap,
+        PlayerDestructions(), occupationsDealer
     )
+
+    val occupations
+        get() = gameInfo.occupations
 
     val currentPlayer
         get() = gameInfo.currentPlayer.name

--- a/core/src/main/gamelogic/Referee.kt
+++ b/core/src/main/gamelogic/Referee.kt
@@ -110,4 +110,3 @@ class CountriesAreNotBorderingException(val from: Country, val to: Country) :
     }
 }
 
-class NotInReinforcingStageException : Exception("Cannot add armies right now.")

--- a/core/src/main/gamelogic/Referee.kt
+++ b/core/src/main/gamelogic/Referee.kt
@@ -62,9 +62,8 @@ class Referee(
     attackerFactory: AttackerFactory = DiceRollingAttackerFactory()
 ) {
 
-
     private val gameInfo = GameInfo(
-        NoState, attackerFactory,
+        attackerFactory,
         players, politicalMap,
         PlayerDestructions(), occupationsDealer
     )

--- a/core/src/main/gamelogic/Referee.kt
+++ b/core/src/main/gamelogic/Referee.kt
@@ -6,7 +6,6 @@ import PositiveInt
 import gamelogic.combat.AttackerFactory
 import gamelogic.combat.DiceRollingAttackerFactory
 import gamelogic.gameState.GameState
-import gamelogic.gameState.NoState
 import gamelogic.gameState.ReinforceState
 import gamelogic.map.PoliticalMap
 import gamelogic.occupations.CountryOccupations
@@ -63,7 +62,7 @@ class Referee(
 ) {
 
     private val gameInfo = GameInfo(
-        attackerFactory, players, politicalMap, occupationsDealer
+        players, politicalMap, occupationsDealer, attackerFactory
     )
 
     val occupations
@@ -72,21 +71,14 @@ class Referee(
     val currentPlayer
         get() = gameInfo.currentPlayer.name
 
-    private var state: GameState
+    private val state: GameState
         get() = gameInfo.state
-        set(value) {
-            gameInfo.state = value
-        }
 
     val gameIsOver: Boolean
         get() = players.any { it.reachedTheGoal(gameInfo) }
 
     val winners: List<Player>
         get() = players.filter { it.reachedTheGoal(gameInfo) }.map { it.name }
-
-    init {
-        state = ReinforceState(gameInfo)
-    }
 
     fun addArmies(reinforcements: List<CountryReinforcement>) =
         state.addArmies(reinforcements)

--- a/core/src/main/gamelogic/Referee.kt
+++ b/core/src/main/gamelogic/Referee.kt
@@ -5,7 +5,9 @@ import Player
 import PositiveInt
 import gamelogic.combat.AttackerFactory
 import gamelogic.combat.DiceRollingAttackerFactory
-import gamelogic.combat.Occupier
+import gamelogic.gameState.GameState
+import gamelogic.gameState.NoState
+import gamelogic.gameState.ReinforceState
 import gamelogic.map.PoliticalMap
 import gamelogic.occupations.CountryOccupations
 import gamelogic.occupations.dealers.OccupationsDealer

--- a/core/src/main/gamelogic/Referee.kt
+++ b/core/src/main/gamelogic/Referee.kt
@@ -60,14 +60,3 @@ class Referee(
 
     fun regroup(regroupings: List<Regrouping>) = state.regroup(regroupings)
 }
-
-class CountriesAreNotBorderingException(val from: Country, val to: Country) :
-    Exception("Countries $from and $to are not bordering.")
-{
-    fun assertAreBorderingIn(politicalMap: PoliticalMap) {
-        if (!politicalMap.areBordering(from, to)) {
-            throw this
-        }
-    }
-}
-

--- a/core/src/main/gamelogic/Regrouping.kt
+++ b/core/src/main/gamelogic/Regrouping.kt
@@ -1,0 +1,26 @@
+package gamelogic
+
+import Country
+import PositiveInt
+import gamelogic.occupations.CountryOccupations
+
+/**
+ * preconditions (checked in [Referee.validateRegroupings] method):
+ *      1. `regroupings.distinctBy { it.from }.count() == regroupings.count()`
+ *      2. occupier of from and to is the same as the currentPlayer
+ */
+class Regrouping(val from: Country, val to: Country, val armies: PositiveInt) {
+    fun validate(gameInfo: GameInfo) {
+        if (gameInfo.occupations.armiesOf(from) <= armies.toInt()) {
+            throw Exception(
+                "Cannot move ${armies.toInt()} armies if they are not available in country")
+        }
+        CountriesAreNotBorderingException(from, to)
+            .assertAreBorderingIn(gameInfo.politicalMap)
+    }
+
+    fun apply(occupations: CountryOccupations) {
+        occupations.removeArmies(from, armies)
+        occupations.addArmies(to, armies)
+    }
+}

--- a/core/src/main/gamelogic/gameState/AttackState.kt
+++ b/core/src/main/gamelogic/gameState/AttackState.kt
@@ -1,36 +1,11 @@
-package gamelogic
+package gamelogic.gameState
 
 import Country
 import PositiveInt
+import gamelogic.CountriesAreNotBorderingException
+import gamelogic.GameInfo
 import gamelogic.combat.Occupier
 import gamelogic.situations.classicCombat.ClassicCombatDiceAmountCalculator
-
-sealed class GameState {
-    open fun addArmies(reinforcements: Collection<CountryReinforcement>): Unit =
-        throw NotInReinforcingStageException()
-
-    open fun makeAttack(from: Country, to: Country): Unit =
-        throw Exception("Cannot attack when not in attacking state")
-
-    open fun occupyConqueredCountry(armies: PositiveInt): Unit =
-        throw Exception("Cannot occupy when not in attacking state")
-
-    open fun endAttack(): Unit = throw Exception("Cannot end attack if not attacking")
-
-    open fun regroup(regroupings: List<Regrouping>): Unit =
-        throw Exception("Cannot regroup if not regrouping")
-}
-
-object NoState : GameState()
-
-class ReinforceState(private val gameInfo: GameInfo) : GameState() {
-    override fun addArmies(reinforcements: Collection<CountryReinforcement>) {
-        reinforcements.forEach {
-            it.apply(gameInfo.playerIterator.current.name, gameInfo.occupations)
-        }
-        gameInfo.state = AttackState(gameInfo)
-    }
-}
 
 class AttackState(private val gameInfo: GameInfo) : GameState() {
     private var state: State = FightState()
@@ -94,33 +69,3 @@ class AttackState(private val gameInfo: GameInfo) : GameState() {
 class CannotEndAttackWhenOccupyingException : Exception(
     "Cannot end attack when there is a country that must be occupied."
 )
-
-class RegroupState(private val gameInfo: GameInfo) : GameState() {
-    override fun regroup(regroupings: List<Regrouping>) {
-        validateRegroupings(regroupings)
-        regroupings.map { it.apply(gameInfo.occupations) }
-        gameInfo.nextTurn()
-        gameInfo.state = ReinforceState(gameInfo)
-    }
-
-    private fun validateRegroupings(regroupings: List<Regrouping>) {
-        regroupings.forEach { it.validate(gameInfo) }
-        val occupations = gameInfo.occupations
-        val playerName = gameInfo.currentPlayer.name
-        if (
-            regroupings.any {
-                occupations.occupierOf(it.from) != playerName ||
-                    occupations.occupierOf(it.to) != playerName
-            }
-        ) {
-            throw Exception("player must occupy both countries to regroup")
-        }
-
-        if (regroupings.distinctBy { it.from }.count() != regroupings.count()) {
-            throw Exception(
-                "Only one regroup per country per turn is allowed (to facilitate validation)")
-        }
-    }
-}
-
-class NotInReinforcingStageException : Exception("Cannot add armies right now.")

--- a/core/src/main/gamelogic/gameState/AttackState.kt
+++ b/core/src/main/gamelogic/gameState/AttackState.kt
@@ -26,12 +26,10 @@ class AttackState(private val gameInfo: GameInfo) : GameState() {
     private inner class FightState : State {
         override fun makeAttack(from: Country, to: Country) {
             val occupations = gameInfo.occupations
-            val currentPlayerName = gameInfo.currentPlayer.name
-            if (occupations.occupierOf(from) != currentPlayerName) {
-                throw Exception("Player $currentPlayerName does not occupy $from")
-            }
-            val politicalMap = gameInfo.politicalMap
-            CountriesAreNotBorderingException(from, to).assertAreBorderingIn(politicalMap)
+            CountryIsNotOccupiedByPlayerException(from, gameInfo.currentPlayer.name)
+                .assertPlayerOccupiesCountryIn(occupations)
+            CountriesAreNotBorderingException(from, to)
+                .assertAreBorderingIn(gameInfo.politicalMap)
             val attacker = gameInfo.attackerFactory.create(
                 occupations, ClassicCombatDiceAmountCalculator()
             )

--- a/core/src/main/gamelogic/gameState/AttackState.kt
+++ b/core/src/main/gamelogic/gameState/AttackState.kt
@@ -3,6 +3,7 @@ package gamelogic.gameState
 import Country
 import PositiveInt
 import gamelogic.CountriesAreNotBorderingException
+import gamelogic.CountryIsNotOccupiedByPlayerException
 import gamelogic.GameInfo
 import gamelogic.combat.Occupier
 import gamelogic.situations.classicCombat.ClassicCombatDiceAmountCalculator

--- a/core/src/main/gamelogic/gameState/GameState.kt
+++ b/core/src/main/gamelogic/gameState/GameState.kt
@@ -18,10 +18,11 @@ abstract class GameState {
     open fun endAttack(): Unit = throw NotInAttackingStateException()
 
     open fun regroup(regroupings: List<Regrouping>): Unit =
-        throw Exception("Cannot regroup if not regrouping")
+        throw NotInRegroupingStateException()
 }
 
 object NoState : GameState()
 
 class NotInReinforcingStateException : Exception("Cannot add armies right now.")
 class NotInAttackingStateException : Exception("Cannot attack or occupy right now.")
+class NotInRegroupingStateException : Exception("Cannot regroup right now.")

--- a/core/src/main/gamelogic/gameState/GameState.kt
+++ b/core/src/main/gamelogic/gameState/GameState.kt
@@ -15,7 +15,7 @@ abstract class GameState {
     open fun occupyConqueredCountry(armies: PositiveInt): Unit =
         throw NotInAttackingStateException()
 
-    open fun endAttack(): Unit = throw Exception("Cannot end attack if not attacking")
+    open fun endAttack(): Unit = throw NotInAttackingStateException()
 
     open fun regroup(regroupings: List<Regrouping>): Unit =
         throw Exception("Cannot regroup if not regrouping")

--- a/core/src/main/gamelogic/gameState/GameState.kt
+++ b/core/src/main/gamelogic/gameState/GameState.kt
@@ -7,7 +7,7 @@ import gamelogic.Regrouping
 
 abstract class GameState {
     open fun addArmies(reinforcements: Collection<CountryReinforcement>): Unit =
-        throw NotInReinforcingStageException()
+        throw NotInReinforcingStateException()
 
     open fun makeAttack(from: Country, to: Country): Unit =
         throw Exception("Cannot attack when not in attacking state")
@@ -23,4 +23,4 @@ abstract class GameState {
 
 object NoState : GameState()
 
-class NotInReinforcingStageException : Exception("Cannot add armies right now.")
+class NotInReinforcingStateException : Exception("Cannot add armies right now.")

--- a/core/src/main/gamelogic/gameState/GameState.kt
+++ b/core/src/main/gamelogic/gameState/GameState.kt
@@ -1,0 +1,26 @@
+package gamelogic.gameState
+
+import Country
+import PositiveInt
+import gamelogic.CountryReinforcement
+import gamelogic.Regrouping
+
+abstract class GameState {
+    open fun addArmies(reinforcements: Collection<CountryReinforcement>): Unit =
+        throw NotInReinforcingStageException()
+
+    open fun makeAttack(from: Country, to: Country): Unit =
+        throw Exception("Cannot attack when not in attacking state")
+
+    open fun occupyConqueredCountry(armies: PositiveInt): Unit =
+        throw Exception("Cannot occupy when not in attacking state")
+
+    open fun endAttack(): Unit = throw Exception("Cannot end attack if not attacking")
+
+    open fun regroup(regroupings: List<Regrouping>): Unit =
+        throw Exception("Cannot regroup if not regrouping")
+}
+
+object NoState : GameState()
+
+class NotInReinforcingStageException : Exception("Cannot add armies right now.")

--- a/core/src/main/gamelogic/gameState/GameState.kt
+++ b/core/src/main/gamelogic/gameState/GameState.kt
@@ -10,10 +10,10 @@ abstract class GameState {
         throw NotInReinforcingStateException()
 
     open fun makeAttack(from: Country, to: Country): Unit =
-        throw Exception("Cannot attack when not in attacking state")
+        throw NotInAttackingStateException()
 
     open fun occupyConqueredCountry(armies: PositiveInt): Unit =
-        throw Exception("Cannot occupy when not in attacking state")
+        throw NotInAttackingStateException()
 
     open fun endAttack(): Unit = throw Exception("Cannot end attack if not attacking")
 
@@ -24,3 +24,4 @@ abstract class GameState {
 object NoState : GameState()
 
 class NotInReinforcingStateException : Exception("Cannot add armies right now.")
+class NotInAttackingStateException : Exception("Cannot attack or occupy right now.")

--- a/core/src/main/gamelogic/gameState/GameState.kt
+++ b/core/src/main/gamelogic/gameState/GameState.kt
@@ -21,8 +21,6 @@ abstract class GameState {
         throw NotInRegroupingStateException()
 }
 
-object NoState : GameState()
-
 class NotInReinforcingStateException : Exception("Cannot add armies right now.")
 class NotInAttackingStateException : Exception("Cannot attack or occupy right now.")
 class NotInRegroupingStateException : Exception("Cannot regroup right now.")

--- a/core/src/main/gamelogic/gameState/RegroupState.kt
+++ b/core/src/main/gamelogic/gameState/RegroupState.kt
@@ -4,6 +4,7 @@ import Country
 import Player
 import gamelogic.GameInfo
 import gamelogic.Regrouping
+import gamelogic.occupations.CountryOccupations
 
 class RegroupState(private val gameInfo: GameInfo) : GameState() {
     override fun regroup(regroupings: List<Regrouping>) {
@@ -27,13 +28,17 @@ class RegroupState(private val gameInfo: GameInfo) : GameState() {
     }
 
     private fun assertPlayerOccupiesCountry(country: Country) {
-        val occupations = gameInfo.occupations
-        val playerName = gameInfo.currentPlayer.name
-        if (occupations.occupierOf(country) != playerName) {
-            throw CountryIsNotOccupiedByPlayerException(country, playerName)
-        }
+        CountryIsNotOccupiedByPlayerException(country, gameInfo.currentPlayer.name)
+            .assertPlayerOccupiesCountry(gameInfo.occupations)
     }
 }
 
 class CountryIsNotOccupiedByPlayerException(val country: Country, val player: Player) :
     Exception("Country $country is not occupied by $player.")
+{
+    fun assertPlayerOccupiesCountry(occupations: CountryOccupations) {
+        if (occupations.occupierOf(country) != player) {
+            throw this
+        }
+    }
+}

--- a/core/src/main/gamelogic/gameState/RegroupState.kt
+++ b/core/src/main/gamelogic/gameState/RegroupState.kt
@@ -29,14 +29,14 @@ class RegroupState(private val gameInfo: GameInfo) : GameState() {
 
     private fun assertPlayerOccupiesCountry(country: Country) {
         CountryIsNotOccupiedByPlayerException(country, gameInfo.currentPlayer.name)
-            .assertPlayerOccupiesCountry(gameInfo.occupations)
+            .assertPlayerOccupiesCountryIn(gameInfo.occupations)
     }
 }
 
 class CountryIsNotOccupiedByPlayerException(val country: Country, val player: Player) :
     Exception("Country $country is not occupied by $player.")
 {
-    fun assertPlayerOccupiesCountry(occupations: CountryOccupations) {
+    fun assertPlayerOccupiesCountryIn(occupations: CountryOccupations) {
         if (occupations.occupierOf(country) != player) {
             throw this
         }

--- a/core/src/main/gamelogic/gameState/RegroupState.kt
+++ b/core/src/main/gamelogic/gameState/RegroupState.kt
@@ -1,10 +1,9 @@
 package gamelogic.gameState
 
 import Country
-import Player
+import gamelogic.CountryIsNotOccupiedByPlayerException
 import gamelogic.GameInfo
 import gamelogic.Regrouping
-import gamelogic.occupations.CountryOccupations
 
 class RegroupState(private val gameInfo: GameInfo) : GameState() {
     override fun regroup(regroupings: List<Regrouping>) {
@@ -30,15 +29,5 @@ class RegroupState(private val gameInfo: GameInfo) : GameState() {
     private fun assertPlayerOccupiesCountry(country: Country) {
         CountryIsNotOccupiedByPlayerException(country, gameInfo.currentPlayer.name)
             .assertPlayerOccupiesCountryIn(gameInfo.occupations)
-    }
-}
-
-class CountryIsNotOccupiedByPlayerException(val country: Country, val player: Player) :
-    Exception("Country $country is not occupied by $player.")
-{
-    fun assertPlayerOccupiesCountryIn(occupations: CountryOccupations) {
-        if (occupations.occupierOf(country) != player) {
-            throw this
-        }
     }
 }

--- a/core/src/main/gamelogic/gameState/RegroupState.kt
+++ b/core/src/main/gamelogic/gameState/RegroupState.kt
@@ -1,0 +1,32 @@
+package gamelogic.gameState
+
+import gamelogic.GameInfo
+import gamelogic.Regrouping
+
+class RegroupState(private val gameInfo: GameInfo) : GameState() {
+    override fun regroup(regroupings: List<Regrouping>) {
+        validateRegroupings(regroupings)
+        regroupings.map { it.apply(gameInfo.occupations) }
+        gameInfo.nextTurn()
+        gameInfo.state = ReinforceState(gameInfo)
+    }
+
+    private fun validateRegroupings(regroupings: List<Regrouping>) {
+        regroupings.forEach { it.validate(gameInfo) }
+        val occupations = gameInfo.occupations
+        val playerName = gameInfo.currentPlayer.name
+        if (
+            regroupings.any {
+                occupations.occupierOf(it.from) != playerName ||
+                    occupations.occupierOf(it.to) != playerName
+            }
+        ) {
+            throw Exception("player must occupy both countries to regroup")
+        }
+
+        if (regroupings.distinctBy { it.from }.count() != regroupings.count()) {
+            throw Exception(
+                "Only one regroup per country per turn is allowed (to facilitate validation)")
+        }
+    }
+}

--- a/core/src/main/gamelogic/gameState/RegroupState.kt
+++ b/core/src/main/gamelogic/gameState/RegroupState.kt
@@ -1,5 +1,7 @@
 package gamelogic.gameState
 
+import Country
+import Player
 import gamelogic.GameInfo
 import gamelogic.Regrouping
 
@@ -12,16 +14,10 @@ class RegroupState(private val gameInfo: GameInfo) : GameState() {
     }
 
     private fun validateRegroupings(regroupings: List<Regrouping>) {
-        regroupings.forEach { it.validate(gameInfo) }
-        val occupations = gameInfo.occupations
-        val playerName = gameInfo.currentPlayer.name
-        if (
-            regroupings.any {
-                occupations.occupierOf(it.from) != playerName ||
-                    occupations.occupierOf(it.to) != playerName
-            }
-        ) {
-            throw Exception("player must occupy both countries to regroup")
+        regroupings.forEach {
+            it.validate(gameInfo)
+            assertPlayerOccupiesCountry(it.from)
+            assertPlayerOccupiesCountry(it.to)
         }
 
         if (regroupings.distinctBy { it.from }.count() != regroupings.count()) {
@@ -29,4 +25,15 @@ class RegroupState(private val gameInfo: GameInfo) : GameState() {
                 "Only one regroup per country per turn is allowed (to facilitate validation)")
         }
     }
+
+    private fun assertPlayerOccupiesCountry(country: Country) {
+        val occupations = gameInfo.occupations
+        val playerName = gameInfo.currentPlayer.name
+        if (occupations.occupierOf(country) != playerName) {
+            throw CountryIsNotOccupiedByPlayerException(country, playerName)
+        }
+    }
 }
+
+class CountryIsNotOccupiedByPlayerException(val country: Country, val player: Player) :
+    Exception("Country $country is not occupied by $player.")

--- a/core/src/main/gamelogic/gameState/ReinforceState.kt
+++ b/core/src/main/gamelogic/gameState/ReinforceState.kt
@@ -1,0 +1,13 @@
+package gamelogic.gameState
+
+import gamelogic.CountryReinforcement
+import gamelogic.GameInfo
+
+class ReinforceState(private val gameInfo: GameInfo) : GameState() {
+    override fun addArmies(reinforcements: Collection<CountryReinforcement>) {
+        reinforcements.forEach {
+            it.apply(gameInfo.playerIterator.current.name, gameInfo.occupations)
+        }
+        gameInfo.state = AttackState(gameInfo)
+    }
+}

--- a/core/src/test/gamelogic/GoalTest.kt
+++ b/core/src/test/gamelogic/GoalTest.kt
@@ -38,7 +38,7 @@ private fun createGameInfo(
     destroyed: PlayerDestructions = PlayerDestructions()
 ) = GameInfo(
     NoState, DiceRollingAttackerFactory(),
-    players, players.loopingIterator(),
+    players,
     politicalMap, occupations, destroyed
 )
 

--- a/core/src/test/gamelogic/GoalTest.kt
+++ b/core/src/test/gamelogic/GoalTest.kt
@@ -38,7 +38,7 @@ private fun createGameInfo(
     occupations: Collection<Occupation>,
     destroyed: PlayerDestructions = PlayerDestructions()
 ) = GameInfo(
-    NoState, DiceRollingAttackerFactory(),
+    DiceRollingAttackerFactory(),
     players,
     politicalMap, destroyed,
     FixedOccupationsDealer(occupations, players.map { it.name })

--- a/core/src/test/gamelogic/GoalTest.kt
+++ b/core/src/test/gamelogic/GoalTest.kt
@@ -1,6 +1,7 @@
 package gamelogic
 
 import PositiveInt
+import gamelogic.combat.DiceRollingAttackerFactory
 import gamelogic.map.Continent
 import gamelogic.map.PoliticalMap
 import gamelogic.occupations.CountryOccupations
@@ -34,7 +35,11 @@ private fun createGameInfo(
     politicalMap: PoliticalMap,
     occupations: CountryOccupations,
     destroyed: PlayerDestructions = PlayerDestructions()
-) = GameInfo(players, players.loopingIterator(), politicalMap, occupations, destroyed)
+) = GameInfo(
+    NoState, DiceRollingAttackerFactory(),
+    players, players.loopingIterator(),
+    politicalMap, occupations, destroyed
+)
 
 class OccupyContinentTest {
     private val goal: Goal = Goal(listOf(OccupyContinent(SINGLE_COUNTRY_CONTINENT)))

--- a/core/src/test/gamelogic/GoalTest.kt
+++ b/core/src/test/gamelogic/GoalTest.kt
@@ -37,10 +37,10 @@ private fun createGameInfo(
     occupations: Collection<Occupation>,
     destroyed: PlayerDestructions = PlayerDestructions()
 ) = GameInfo(
-    DiceRollingAttackerFactory(),
     players,
     politicalMap,
     FixedOccupationsDealer(occupations, players.map { it.name }),
+    DiceRollingAttackerFactory(),
     destroyed
 )
 

--- a/core/src/test/gamelogic/GoalTest.kt
+++ b/core/src/test/gamelogic/GoalTest.kt
@@ -2,6 +2,7 @@ package gamelogic
 
 import PositiveInt
 import gamelogic.combat.DiceRollingAttackerFactory
+import gamelogic.gameState.NoState
 import gamelogic.map.Continent
 import gamelogic.map.PoliticalMap
 import gamelogic.occupations.CountryOccupations

--- a/core/src/test/gamelogic/GoalTest.kt
+++ b/core/src/test/gamelogic/GoalTest.kt
@@ -5,8 +5,9 @@ import gamelogic.combat.DiceRollingAttackerFactory
 import gamelogic.gameState.NoState
 import gamelogic.map.Continent
 import gamelogic.map.PoliticalMap
-import gamelogic.occupations.CountryOccupations
+import gamelogic.occupations.Occupation
 import gamelogic.occupations.PlayerOccupation
+import gamelogic.occupations.dealers.FixedOccupationsDealer
 import org.junit.Test
 import kotlin.test.assertFails
 import kotlin.test.assertFalse
@@ -17,7 +18,7 @@ private val SINGLE_COUNTRY_CONTINENT = Continent("América", setOf(A_COUNTRY))
 private val SINGLE_COUNTRY_POLITICAL_MAP =
     PoliticalMap.Builder().addContinent(SINGLE_COUNTRY_CONTINENT).build()
 private val SINGLE_COUNTRY_OCCUPATIONS =
-    CountryOccupations(listOf(PlayerOccupation(A_COUNTRY, "Nico", PositiveInt(1))))
+    listOf(PlayerOccupation(A_COUNTRY, "Nico", PositiveInt(1)))
 
 private fun twoPlayersWithGoals(firstGoal: Goal, secondGoal: Goal) =
     mutableListOf(
@@ -34,12 +35,13 @@ private fun createSingleCountryGameInfo(
 private fun createGameInfo(
     players: MutableList<PlayerInfo>,
     politicalMap: PoliticalMap,
-    occupations: CountryOccupations,
+    occupations: Collection<Occupation>,
     destroyed: PlayerDestructions = PlayerDestructions()
 ) = GameInfo(
     NoState, DiceRollingAttackerFactory(),
     players,
-    politicalMap, occupations, destroyed
+    politicalMap, destroyed,
+    FixedOccupationsDealer(occupations, players.map { it.name })
 )
 
 class OccupyContinentTest {
@@ -102,11 +104,11 @@ class OccupySubContinentTest {
         val politicalMap = PoliticalMap.Builder().addContinent(continent).build()
         val goal = Goal(listOf(OccupySubContinent(continent, 1)))
         val players = twoPlayersWithGoals(goal, goal)
-        val occupations = CountryOccupations(
+        val occupations =
             listOf(
                 PlayerOccupation(firstCountry, players[0].name, PositiveInt(1)),
                 PlayerOccupation(secondCountry, players[1].name, PositiveInt(1))
-            ))
+            )
         val gameInfo = createGameInfo(players, politicalMap, occupations)
 
         assertTrue(goal.achieved(players[0], gameInfo))

--- a/core/src/test/gamelogic/GoalTest.kt
+++ b/core/src/test/gamelogic/GoalTest.kt
@@ -2,7 +2,6 @@ package gamelogic
 
 import PositiveInt
 import gamelogic.combat.DiceRollingAttackerFactory
-import gamelogic.gameState.NoState
 import gamelogic.map.Continent
 import gamelogic.map.PoliticalMap
 import gamelogic.occupations.Occupation
@@ -40,8 +39,9 @@ private fun createGameInfo(
 ) = GameInfo(
     DiceRollingAttackerFactory(),
     players,
-    politicalMap, destroyed,
-    FixedOccupationsDealer(occupations, players.map { it.name })
+    politicalMap,
+    FixedOccupationsDealer(occupations, players.map { it.name }),
+    destroyed
 )
 
 class OccupyContinentTest {

--- a/core/src/test/gamelogic/RefereeTest.kt
+++ b/core/src/test/gamelogic/RefereeTest.kt
@@ -157,10 +157,9 @@ class RefereeTest {
         val reinforcements = listOf(CountryReinforcement(arg, PositiveInt(3)))
         referee.addArmies(reinforcements)
         referee.makeAttack(arg, bra)
+
         assertTrue(referee.occupations.isEmpty(bra))
         assertEquals(referee.occupations.armiesOf(arg), 4)
-
-        referee.endAttack()
         assertEquals(referee.occupations.armiesOf(kam), 1)
         assertEquals(referee.occupations.armiesOf(chi), 1)
         assertEquals(referee.occupations.armiesOf(jap), 1)
@@ -310,5 +309,24 @@ class RefereeTest {
         politicalMap.countries.forEach { country ->
             assertEquals(1, sampleReferee.occupations.armiesOf(country))
         }
+    }
+
+    @Test
+    fun `Cannot end attack when occupying`() {
+        val referee = Referee(
+            players,
+            politicalMap,
+            FixedOccupationsDealer(occupationsSample, playerNames),
+            AttackingCountryWinsAttackerFactory(PositiveInt(4), PositiveInt(1))
+        )
+        referee.addArmies(listOf(CountryReinforcement(arg, PositiveInt(3))))
+        referee.makeAttack(arg, bra)
+
+        assertFailsWith<CannotEndAttackWhenOccupyingException> {
+            referee.endAttack()
+        }
+
+        assertEquals(4, referee.occupations.armiesOf(arg))
+        assertEquals(0, referee.occupations.armiesOf(bra))
     }
 }

--- a/core/src/test/gamelogic/RefereeTest.kt
+++ b/core/src/test/gamelogic/RefereeTest.kt
@@ -2,6 +2,8 @@ package gamelogic
 
 import PositiveInt
 import gamelogic.combat.AttackingCountryWinsAttackerFactory
+import gamelogic.gameState.CannotEndAttackWhenOccupyingException
+import gamelogic.gameState.NotInReinforcingStageException
 import gamelogic.map.Continent
 import gamelogic.map.PoliticalMap
 import gamelogic.occupations.PlayerOccupation

--- a/core/src/test/gamelogic/RefereeTest.kt
+++ b/core/src/test/gamelogic/RefereeTest.kt
@@ -123,7 +123,7 @@ class RefereeTest {
         val reinforcements = listOf(CountryReinforcement(arg, armiesToAdd))
         val armiesBefore = sampleReferee.occupations.armiesOf(arg)
         sampleReferee.addArmies(reinforcements)
-        assertEquals(sampleReferee.currentState, Referee.State.Attack)
+        assertEquals(sampleReferee.currentState, GameState.Attack)
         assertEquals(
             sampleReferee.occupations.armiesOf(arg), (armiesToAdd + armiesBefore).toInt())
     }
@@ -133,7 +133,7 @@ class RefereeTest {
         val reinforcements = listOf(CountryReinforcement(arg, PositiveInt(1)))
         sampleReferee.addArmies(reinforcements)
         sampleReferee.endAttack()
-        assertEquals(sampleReferee.currentState, Referee.State.Regroup)
+        assertEquals(sampleReferee.currentState, GameState.Regroup)
     }
 
     @Test
@@ -149,7 +149,7 @@ class RefereeTest {
         referee.endAttack()
         referee.regroup(listOf(Regrouping(arg, chi, PositiveInt(2))))
         assertEquals(referee.occupations.armiesOf(chi), 3)
-        assertEquals(referee.currentState, Referee.State.AddArmies)
+        assertEquals(referee.currentState, GameState.AddArmies)
         assertEquals(referee.currentPlayer, eric)
     }
 
@@ -298,5 +298,27 @@ class RefereeTest {
         assertEquals(kam, exception.to)
         assertEquals(3, sampleReferee.occupations.armiesOf(arg))
         assertEquals(1, sampleReferee.occupations.armiesOf(kam))
+    }
+
+    @Test
+    fun `Cannot add armies to a country not occupied by the current player`() {
+        assertFails {
+            sampleReferee.addArmies(listOf(CountryReinforcement(bra, PositiveInt(1))))
+        }
+
+        assertEquals(1, sampleReferee.occupations.armiesOf(bra))
+    }
+
+    @Test
+    fun `Cannot reinforce when not in reinforcing state`() {
+        sampleReferee.addArmies(listOf())
+
+        assertFailsWith<NotInReinforcingStageException> {
+            sampleReferee.addArmies(listOf())
+        }
+
+        politicalMap.countries.forEach { country ->
+            assertEquals(1, sampleReferee.occupations.armiesOf(country))
+        }
     }
 }

--- a/core/src/test/gamelogic/RefereeTest.kt
+++ b/core/src/test/gamelogic/RefereeTest.kt
@@ -335,4 +335,11 @@ class RefereeTest {
         assertEquals(4, referee.occupations.armiesOf(arg))
         assertEquals(0, referee.occupations.armiesOf(bra))
     }
+
+    @Test
+    fun `Cannot end attack if not attacking`() {
+        assertFailsWith<NotInAttackingStateException> {
+            sampleReferee.endAttack()
+        }
+    }
 }

--- a/core/src/test/gamelogic/RefereeTest.kt
+++ b/core/src/test/gamelogic/RefereeTest.kt
@@ -3,7 +3,7 @@ package gamelogic
 import PositiveInt
 import gamelogic.combat.AttackingCountryWinsAttackerFactory
 import gamelogic.gameState.CannotEndAttackWhenOccupyingException
-import gamelogic.gameState.NotInReinforcingStageException
+import gamelogic.gameState.NotInReinforcingStateException
 import gamelogic.map.Continent
 import gamelogic.map.PoliticalMap
 import gamelogic.occupations.PlayerOccupation
@@ -304,7 +304,7 @@ class RefereeTest {
     fun `Cannot reinforce when not in reinforcing state`() {
         sampleReferee.addArmies(listOf())
 
-        assertFailsWith<NotInReinforcingStageException> {
+        assertFailsWith<NotInReinforcingStateException> {
             sampleReferee.addArmies(listOf())
         }
 

--- a/core/src/test/gamelogic/RefereeTest.kt
+++ b/core/src/test/gamelogic/RefereeTest.kt
@@ -2,10 +2,7 @@ package gamelogic
 
 import PositiveInt
 import gamelogic.combat.AttackingCountryWinsAttackerFactory
-import gamelogic.gameState.CannotEndAttackWhenOccupyingException
-import gamelogic.gameState.NotInAttackingStateException
-import gamelogic.gameState.NotInRegroupingStateException
-import gamelogic.gameState.NotInReinforcingStateException
+import gamelogic.gameState.*
 import gamelogic.map.Continent
 import gamelogic.map.PoliticalMap
 import gamelogic.occupations.PlayerOccupation
@@ -349,5 +346,36 @@ class RefereeTest {
         assertFailsWith<NotInRegroupingStateException> {
             sampleReferee.regroup(listOf())
         }
+    }
+
+    @Test
+    fun `Cannot regroup to a country that does not belong to the current player`() {
+        sampleRefereeLarge.addArmies(listOf(CountryReinforcement(arg, PositiveInt(1))))
+        sampleRefereeLarge.endAttack()
+        val exception = assertFailsWith<CountryIsNotOccupiedByPlayerException> {
+            sampleRefereeLarge.regroup(listOf(Regrouping(arg, bra, PositiveInt(1))))
+        }
+
+        assertEquals(bra, exception.country)
+        assertEquals(nico, exception.player)
+        assertEquals(2, sampleRefereeLarge.occupations.armiesOf(arg))
+        assertEquals(1, sampleRefereeLarge.occupations.armiesOf(bra))
+    }
+
+    @Test
+    fun `Cannot regroup from a country that does not belong to the current player`() {
+        sampleRefereeLarge.addArmies(listOf(CountryReinforcement(arg, PositiveInt(1))))
+        sampleRefereeLarge.endAttack()
+        sampleRefereeLarge.regroup(listOf())
+        sampleRefereeLarge.addArmies(listOf())
+        sampleRefereeLarge.endAttack()
+        val exception = assertFailsWith<CountryIsNotOccupiedByPlayerException> {
+            sampleRefereeLarge.regroup(listOf(Regrouping(arg, bra, PositiveInt(1))))
+        }
+
+        assertEquals(arg, exception.country)
+        assertEquals(eric, exception.player)
+        assertEquals(2, sampleRefereeLarge.occupations.armiesOf(arg))
+        assertEquals(1, sampleRefereeLarge.occupations.armiesOf(bra))
     }
 }

--- a/core/src/test/gamelogic/RefereeTest.kt
+++ b/core/src/test/gamelogic/RefereeTest.kt
@@ -259,9 +259,14 @@ class RefereeTest {
         sampleReferee.regroup(emptyList())
         sampleReferee.addArmies(emptyList())
 
-        assertFails {
+        val exception = assertFailsWith<CountryIsNotOccupiedByPlayerException> {
             sampleReferee.makeAttack(arg, bra)
         }
+
+        assertEquals(arg, exception.country)
+        assertEquals(eric, exception.player)
+        assertEquals(3, sampleReferee.occupations.armiesOf(arg))
+        assertEquals(1, sampleReferee.occupations.armiesOf(bra))
     }
 
     @Test

--- a/core/src/test/gamelogic/RefereeTest.kt
+++ b/core/src/test/gamelogic/RefereeTest.kt
@@ -4,6 +4,7 @@ import PositiveInt
 import gamelogic.combat.AttackingCountryWinsAttackerFactory
 import gamelogic.gameState.CannotEndAttackWhenOccupyingException
 import gamelogic.gameState.NotInAttackingStateException
+import gamelogic.gameState.NotInRegroupingStateException
 import gamelogic.gameState.NotInReinforcingStateException
 import gamelogic.map.Continent
 import gamelogic.map.PoliticalMap
@@ -340,6 +341,13 @@ class RefereeTest {
     fun `Cannot end attack if not attacking`() {
         assertFailsWith<NotInAttackingStateException> {
             sampleReferee.endAttack()
+        }
+    }
+
+    @Test
+    fun `Cannot regroup if not regrouping`() {
+        assertFailsWith<NotInRegroupingStateException> {
+            sampleReferee.regroup(listOf())
         }
     }
 }

--- a/core/src/test/gamelogic/RefereeTest.kt
+++ b/core/src/test/gamelogic/RefereeTest.kt
@@ -3,6 +3,7 @@ package gamelogic
 import PositiveInt
 import gamelogic.combat.AttackingCountryWinsAttackerFactory
 import gamelogic.gameState.CannotEndAttackWhenOccupyingException
+import gamelogic.gameState.NotInAttackingStateException
 import gamelogic.gameState.NotInReinforcingStateException
 import gamelogic.map.Continent
 import gamelogic.map.PoliticalMap
@@ -217,9 +218,12 @@ class RefereeTest {
     fun `Cannot attack when not in attacking state`() {
         sampleReferee.addArmies(listOf(CountryReinforcement(arg, PositiveInt(2))))
         sampleReferee.endAttack()
-        assertFails {
+        assertFailsWith<NotInAttackingStateException> {
             sampleReferee.makeAttack(arg, bra)
         }
+
+        assertEquals(3, sampleReferee.occupations.armiesOf(arg))
+        assertEquals(1, sampleReferee.occupations.armiesOf(bra))
     }
 
     @Test

--- a/core/src/test/gamelogic/RefereeTest.kt
+++ b/core/src/test/gamelogic/RefereeTest.kt
@@ -118,22 +118,13 @@ class RefereeTest {
     }
 
     @Test
-    fun `AddArmies adds armies and changes referee's state`() {
+    fun `AddArmies adds armies`() {
         val armiesToAdd = PositiveInt(1)
         val reinforcements = listOf(CountryReinforcement(arg, armiesToAdd))
         val armiesBefore = sampleReferee.occupations.armiesOf(arg)
         sampleReferee.addArmies(reinforcements)
-        assertEquals(sampleReferee.currentState, GameState.Attack)
         assertEquals(
             sampleReferee.occupations.armiesOf(arg), (armiesToAdd + armiesBefore).toInt())
-    }
-
-    @Test
-    fun `EndAttack ends the attack`() {
-        val reinforcements = listOf(CountryReinforcement(arg, PositiveInt(1)))
-        sampleReferee.addArmies(reinforcements)
-        sampleReferee.endAttack()
-        assertEquals(sampleReferee.currentState, GameState.Regroup)
     }
 
     @Test
@@ -149,7 +140,6 @@ class RefereeTest {
         referee.endAttack()
         referee.regroup(listOf(Regrouping(arg, chi, PositiveInt(2))))
         assertEquals(referee.occupations.armiesOf(chi), 3)
-        assertEquals(referee.currentState, GameState.AddArmies)
         assertEquals(referee.currentPlayer, eric)
     }
 

--- a/core/src/test/gamelogic/RefereeTest.kt
+++ b/core/src/test/gamelogic/RefereeTest.kt
@@ -300,10 +300,12 @@ class RefereeTest {
 
     @Test
     fun `Cannot add armies to a country not occupied by the current player`() {
-        assertFails {
+        val exception = assertFailsWith<CountryIsNotOccupiedByPlayerException> {
             sampleReferee.addArmies(listOf(CountryReinforcement(bra, PositiveInt(1))))
         }
 
+        assertEquals(bra, exception.country)
+        assertEquals(nico, exception.player)
         assertEquals(1, sampleReferee.occupations.armiesOf(bra))
     }
 


### PR DESCRIPTION
Delega la responsabilidad de todo a los `GameState`s. Si seguíamos sin separar esto el `Referee` iba a quedar gigante y lleno de ifs que checkeaban el State para saber qué hacer.